### PR TITLE
Add initial test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExpenseTracker",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // The main executable target for the application.
+        .executableTarget(
+            name: "ExpenseTracker"),
+
+        // Test suite target using XCTest
+        .testTarget(
+            name: "ExpenseTrackerTests",
+            dependencies: ["ExpenseTracker"]),
+    ]
+)

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import ExpenseTracker
+
+final class ExpenseTrackerTests: XCTestCase {
+    func testExample() throws {
+        // Placeholder test to establish structure
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- set up Swift package for `ExpenseTracker`
- add `ExpenseTrackerTests` test target using XCTest
- provide placeholder test example

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_683fa76b7058832080644bf889dd4b44