### PR TITLE
Improve README with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # ExpenseTracker
-OCR receipt/expense tracker app
+
+ExpenseTracker is an app designed to help you scan receipts, organize expenses, and visualize spending over time.
+
+## Goals
+
+- **Receipt OCR**: Use optical character recognition (OCR) to extract details from receipts.
+- **Expense organization**: Categorize each expense for easy tracking.
+- **Monthly visualization**: Summarize spending with monthly charts.
+
+## Building the Project
+
+1. Open `ExpenseTracker.xcodeproj` in Xcode 14 or later.
+2. Ensure you have the iOS 15 SDK or later installed.
+3. Select an iOS simulator (or a connected device) and press **Run**.
+
+## Running on a Device
+
+- Connect an iPhone or iPad and select it as the target device in Xcode.
+- Ensure the deployment target of the project matches or is lower than your device's iOS version.
+
+## Contributing and Testing
+
+Contributions are welcome! Fork the repository, create a feature branch, and open a pull request.
+
+To run tests, use the Xcode menu `Product` > `Test` or run the following command from the project directory:
+
+```bash
+xcodebuild test -scheme ExpenseTracker -destination 'platform=iOS Simulator,name=iPhone 14'
+```
+


### PR DESCRIPTION
## Summary
- outline app goals for OCR expense tracking
- add build instructions for Xcode and running on devices
- mention contributing and testing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fa76708bc832083115245f26a76c2