### PR TITLE
Add SwiftUI starter project with modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker.xcodeproj/project.pbxproj
@@ -1,0 +1,356 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2231701B6831474E13FEC35A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAA99FB018F0D8DE60AF0049 /* UIKit.framework */; };
+		C0779FB01DA09A0021662954 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F3C5114118050D3CC29C9DA /* CoreData.framework */; };
+		CF585195A84F8E85DD280033 /* Vision.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 443CB1320241246FA11F4946 /* Vision.framework */; };
+		E8D31959AC8329499090BDFB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFC5A944CB7E9560B5072C5F /* Foundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1F3110964976BE6613FBD81C /* ExpenseTrackerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExpenseTrackerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C75A305E083A584F490720D /* ChartsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChartsView.swift; path = Sources/ChartsModule/ChartsView.swift; sourceTree = "<group>"; };
+		2CF2E40334EFE2DBD83F9201 /* main.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = main.swift; path = Sources/ExpenseTrackerApp/main.swift; sourceTree = "<group>"; };
+		3AFECF13EA13825B53E03A87 /* ReceiptCapture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiptCapture.swift; path = Sources/ReceiptCapture/ReceiptCapture.swift; sourceTree = "<group>"; };
+		443CB1320241246FA11F4946 /* Vision.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vision.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Vision.framework; sourceTree = DEVELOPER_DIR; };
+		7F3C5114118050D3CC29C9DA /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		BE847D4F163F79729DE816DC /* DataController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataController.swift; path = Sources/DataModel/DataController.swift; sourceTree = "<group>"; };
+		BFC5A944CB7E9560B5072C5F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		CAA99FB018F0D8DE60AF0049 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		254A772E79D524C01276E86D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E8D31959AC8329499090BDFB /* Foundation.framework in Frameworks */,
+				2231701B6831474E13FEC35A /* UIKit.framework in Frameworks */,
+				CF585195A84F8E85DD280033 /* Vision.framework in Frameworks */,
+				C0779FB01DA09A0021662954 /* CoreData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5E47858E8049B6B184BDFFAF = {
+			isa = PBXGroup;
+			children = (
+				D85468E30F24E69F667B4748 /* Products */,
+				772F3A8B036D0E60A89B6470 /* Frameworks */,
+				7622B94FB2566B7AD9404EA7 /* ExpenseTrackerApp */,
+				A0703876A8E42284D67C2A6E /* ReceiptCapture */,
+				9A46682923D1EA65696AEA11 /* DataModel */,
+				8BD58AC6DE6974690E1C698B /* ChartsModule */,
+			);
+			sourceTree = "<group>";
+		};
+		7622B94FB2566B7AD9404EA7 /* ExpenseTrackerApp */ = {
+			isa = PBXGroup;
+			children = (
+				2CF2E40334EFE2DBD83F9201 /* main.swift */,
+			);
+			name = ExpenseTrackerApp;
+			path = Sources/ExpenseTrackerApp;
+			sourceTree = "<group>";
+		};
+		772F3A8B036D0E60A89B6470 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AF57B1DE496B0EC55DCB41E9 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8BD58AC6DE6974690E1C698B /* ChartsModule */ = {
+			isa = PBXGroup;
+			children = (
+				2C75A305E083A584F490720D /* ChartsView.swift */,
+			);
+			name = ChartsModule;
+			path = Sources/ChartsModule;
+			sourceTree = "<group>";
+		};
+		9A46682923D1EA65696AEA11 /* DataModel */ = {
+			isa = PBXGroup;
+			children = (
+				BE847D4F163F79729DE816DC /* DataController.swift */,
+			);
+			name = DataModel;
+			path = Sources/DataModel;
+			sourceTree = "<group>";
+		};
+		A0703876A8E42284D67C2A6E /* ReceiptCapture */ = {
+			isa = PBXGroup;
+			children = (
+				3AFECF13EA13825B53E03A87 /* ReceiptCapture.swift */,
+			);
+			name = ReceiptCapture;
+			path = Sources/ReceiptCapture;
+			sourceTree = "<group>";
+		};
+		AF57B1DE496B0EC55DCB41E9 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BFC5A944CB7E9560B5072C5F /* Foundation.framework */,
+				CAA99FB018F0D8DE60AF0049 /* UIKit.framework */,
+				443CB1320241246FA11F4946 /* Vision.framework */,
+				7F3C5114118050D3CC29C9DA /* CoreData.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D85468E30F24E69F667B4748 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1F3110964976BE6613FBD81C /* ExpenseTrackerApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5A103CC3F1927C27928F337D /* ExpenseTrackerApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E467034F956088596824FA62 /* Build configuration list for PBXNativeTarget "ExpenseTrackerApp" */;
+			buildPhases = (
+				EA06C687EB2D46DD9E2E742B /* Sources */,
+				254A772E79D524C01276E86D /* Frameworks */,
+				5845F37B762973E96E7A8C36 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ExpenseTrackerApp;
+			productName = ExpenseTrackerApp;
+			productReference = 1F3110964976BE6613FBD81C /* ExpenseTrackerApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B61054FD32A27308C74AE292 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
+			};
+			buildConfigurationList = 992BC3EE8780CF7818B64241 /* Build configuration list for PBXProject "ExpenseTracker" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5E47858E8049B6B184BDFFAF;
+			productRefGroup = D85468E30F24E69F667B4748 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5A103CC3F1927C27928F337D /* ExpenseTrackerApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5845F37B762973E96E7A8C36 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EA06C687EB2D46DD9E2E742B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2C45D21CEE61263F3F8F2453 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		41606F2EE2F682ADC0071003 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		48EE56873049FA0B989A0B63 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.expensetracker;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EAE719177EFA0632E1BD9A0F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.expensetracker;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		992BC3EE8780CF7818B64241 /* Build configuration list for PBXProject "ExpenseTracker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2C45D21CEE61263F3F8F2453 /* Debug */,
+				41606F2EE2F682ADC0071003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E467034F956088596824FA62 /* Build configuration list for PBXNativeTarget "ExpenseTrackerApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48EE56873049FA0B989A0B63 /* Release */,
+				EAE719177EFA0632E1BD9A0F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B61054FD32A27308C74AE292 /* Project object */;
+}

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,8 @@ import PackageDescription
 
 let package = Package(
     name: "ExpenseTracker",
+    // Specify iOS 16 when building for iOS, but allow other platforms such as
+    // Linux where these frameworks are unavailable.
     platforms: [
         .iOS(.v16)
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "ExpenseTracker",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(name: "ReceiptCapture", targets: ["ReceiptCapture"]),
+        .library(name: "DataModel", targets: ["DataModel"]),
+        .library(name: "ChartsModule", targets: ["ChartsModule"]),
+        .executable(name: "ExpenseTrackerApp", targets: ["ExpenseTrackerApp"])
+    ],
+    targets: [
+        .target(
+            name: "ReceiptCapture",
+            dependencies: []),
+        .target(
+            name: "DataModel",
+            dependencies: []),
+        .target(
+            name: "ChartsModule",
+            dependencies: []),
+        .executableTarget(
+            name: "ExpenseTrackerApp",
+            dependencies: ["ReceiptCapture", "DataModel", "ChartsModule"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ExpenseTracker
-OCR receipt/expense tracker app
+
+Starter SwiftUI project for tracking expenses with OCR capabilities.
+
+## Modules
+- `ReceiptCapture`: Processes receipt images using the Vision framework.
+- `DataModel`: CoreData stack for persisting expenses.
+- `ChartsModule`: Basic charts for monthly summaries (requires iOS 16+).
+- `ExpenseTrackerApp`: SwiftUI entry point that ties everything together.
+
+## Xcode Project
+An Xcode project can be generated using the included Ruby script:
+
+```bash
+ruby generate_project.rb
+```
+
+Open `ExpenseTracker.xcodeproj` in Xcode to run the app on iOS.

--- a/Sources/ChartsModule/ChartsView.swift
+++ b/Sources/ChartsModule/ChartsView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import Charts
+
+@available(iOS 16.0, *)
+public struct MonthlySummaryChart: View {
+    public var data: [Double]
+
+    public init(data: [Double]) {
+        self.data = data
+    }
+
+    public var body: some View {
+        Chart {
+            ForEach(data.indices, id: \.self) { i in
+                BarMark(x: .value("Month", i), y: .value("Amount", data[i]))
+            }
+        }
+    }
+}

--- a/Sources/ChartsModule/ChartsView.swift
+++ b/Sources/ChartsModule/ChartsView.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI) && canImport(Charts)
 import SwiftUI
 import Charts
 
@@ -17,3 +18,11 @@ public struct MonthlySummaryChart: View {
         }
     }
 }
+#else
+public struct MonthlySummaryChart {
+    public var data: [Double]
+    public init(data: [Double]) {
+        self.data = data
+    }
+}
+#endif

--- a/Sources/DataModel/DataController.swift
+++ b/Sources/DataModel/DataController.swift
@@ -1,6 +1,10 @@
 import Foundation
+#if canImport(CoreData)
 import CoreData
+#endif
 
+#if canImport(CoreData)
+@MainActor
 public class DataController {
     public static let shared = DataController()
     public let container: NSPersistentContainer
@@ -21,3 +25,13 @@ public class DataController {
         }
     }
 }
+#else
+@MainActor
+/// Stub controller used on platforms without CoreData (e.g., Linux). This allows
+/// the package to build even when the CoreData framework is unavailable.
+public class DataController {
+    public static let shared = DataController()
+    private init() {}
+    public func saveContext() {}
+}
+#endif

--- a/Sources/DataModel/DataController.swift
+++ b/Sources/DataModel/DataController.swift
@@ -1,0 +1,23 @@
+import Foundation
+import CoreData
+
+public class DataController {
+    public static let shared = DataController()
+    public let container: NSPersistentContainer
+
+    private init() {
+        container = NSPersistentContainer(name: "ExpenseTrackerModel")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unresolved error \(error)")
+            }
+        }
+    }
+
+    public func saveContext() {
+        let context = container.viewContext
+        if context.hasChanges {
+            try? context.save()
+        }
+    }
+}

--- a/Sources/ExpenseTrackerApp/main.swift
+++ b/Sources/ExpenseTrackerApp/main.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import ReceiptCapture
+import DataModel
+import ChartsModule
+
+@main
+struct ExpenseTrackerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        Text("Expense Tracker")
+    }
+}

--- a/Sources/ExpenseTrackerApp/main.swift
+++ b/Sources/ExpenseTrackerApp/main.swift
@@ -1,7 +1,8 @@
-import SwiftUI
 import ReceiptCapture
 import DataModel
 import ChartsModule
+#if canImport(SwiftUI)
+import SwiftUI
 
 @main
 struct ExpenseTrackerApp: App {
@@ -17,3 +18,11 @@ struct ContentView: View {
         Text("Expense Tracker")
     }
 }
+#else
+@main
+struct ExpenseTrackerApp {
+    static func main() {
+        print("ExpenseTrackerApp requires SwiftUI")
+    }
+}
+#endif

--- a/Sources/ReceiptCapture/ReceiptCapture.swift
+++ b/Sources/ReceiptCapture/ReceiptCapture.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 #if canImport(UIKit)
 import UIKit
 import Vision
@@ -7,7 +8,7 @@ public class ReceiptCapture {
     public init() {}
     // Placeholder method to process a receipt image using Vision
     public func recognizeText(from image: UIImage, completion: @escaping (String?) -> Void) {
-        let request = VNRecognizeTextRequest { request, error in
+        let request = VNRecognizeTextRequest { request, _ in
             if let observations = request.results as? [VNRecognizedTextObservation] {
                 let recognized = observations.compactMap { $0.topCandidates(1).first?.string }.joined(separator: " ")
                 completion(recognized)
@@ -17,6 +18,15 @@ public class ReceiptCapture {
         }
         let handler = VNImageRequestHandler(cgImage: image.cgImage!, options: [:])
         try? handler.perform([request])
+    }
+}
+#else
+/// Stub implementation used on platforms without UIKit/Vision (e.g. Linux).
+/// The method signatures are simplified so the module can still be imported.
+public class ReceiptCapture {
+    public init() {}
+    public func recognizeText(from imagePath: String, completion: @escaping (String?) -> Void) {
+        completion(nil)
     }
 }
 #endif

--- a/Sources/ReceiptCapture/ReceiptCapture.swift
+++ b/Sources/ReceiptCapture/ReceiptCapture.swift
@@ -1,0 +1,22 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+import Vision
+
+public class ReceiptCapture {
+    public init() {}
+    // Placeholder method to process a receipt image using Vision
+    public func recognizeText(from image: UIImage, completion: @escaping (String?) -> Void) {
+        let request = VNRecognizeTextRequest { request, error in
+            if let observations = request.results as? [VNRecognizedTextObservation] {
+                let recognized = observations.compactMap { $0.topCandidates(1).first?.string }.joined(separator: " ")
+                completion(recognized)
+            } else {
+                completion(nil)
+            }
+        }
+        let handler = VNImageRequestHandler(cgImage: image.cgImage!, options: [:])
+        try? handler.perform([request])
+    }
+}
+#endif

--- a/generate_project.rb
+++ b/generate_project.rb
@@ -1,0 +1,25 @@
+require 'xcodeproj'
+
+project_path = 'ExpenseTracker.xcodeproj'
+project = Xcodeproj::Project.new(project_path)
+
+app_target = project.new_target(:application, 'ExpenseTrackerApp', :ios, '16.0')
+
+['ExpenseTrackerApp', 'ReceiptCapture', 'DataModel', 'ChartsModule'].each do |group_name|
+  group = project.new_group(group_name, "Sources/#{group_name}")
+  Dir.glob("Sources/#{group_name}/*.swift").each do |file|
+    group.new_file(file)
+  end
+end
+
+app_target.add_system_framework('UIKit')
+app_target.add_system_framework('Vision')
+app_target.add_system_framework('CoreData')
+
+app_target.build_configurations.each do |config|
+  config.build_settings['SWIFT_VERSION'] = '5.9'
+  config.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'com.example.expensetracker'
+end
+
+project.save
+puts "Created #{project_path}"


### PR DESCRIPTION
## Summary
- initialize Swift package and add placeholder modules
- add sample SwiftUI entry point
- create Ruby script to generate `ExpenseTracker.xcodeproj`
- document modules and project generation steps

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683fa760dd9c8320b7d504e1f4b1ebcb