### PR TITLE
Handle CGImage orientation in OCR

### DIFF
--- a/Sources/ReceiptScanner/ReceiptScanner.swift
+++ b/Sources/ReceiptScanner/ReceiptScanner.swift
@@ -23,7 +23,8 @@ public class ReceiptScanner {
             completion(.success(texts))
         }
         request.recognitionLevel = .accurate
-        let handler = VNImageRequestHandler(cgImage: cgImage)
+        let orientation = CGImagePropertyOrientation(image.imageOrientation)
+        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: orientation)
         DispatchQueue.global().async {
             do {
                 try handler.perform([request])
@@ -35,6 +36,22 @@ public class ReceiptScanner {
 
     public enum ScannerError: Error {
         case invalidImage
+    }
+}
+
+extension CGImagePropertyOrientation {
+    init(_ orientation: UIImage.Orientation) {
+        switch orientation {
+        case .up: self = .up
+        case .down: self = .down
+        case .left: self = .left
+        case .right: self = .right
+        case .upMirrored: self = .upMirrored
+        case .downMirrored: self = .downMirrored
+        case .leftMirrored: self = .leftMirrored
+        case .rightMirrored: self = .rightMirrored
+        @unknown default: self = .up
+        }
     }
 }
 #else

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -6,4 +6,34 @@ final class ExpenseTrackerTests: XCTestCase {
         // Placeholder test to establish structure
         XCTAssertTrue(true)
     }
+
+    func testScanRotatedImage() throws {
+#if os(iOS)
+        let text = "Hello"
+        let font = UIFont.systemFont(ofSize: 40)
+        let size = (text as NSString).size(withAttributes: [.font: font])
+        UIGraphicsBeginImageContextWithOptions(size, false, 1)
+        defer { UIGraphicsEndImageContext() }
+        (text as NSString).draw(at: .zero, withAttributes: [.font: font])
+        guard let baseImage = UIGraphicsGetImageFromCurrentImageContext() else {
+            XCTFail("Failed to create base image")
+            return
+        }
+        let rotated = UIImage(cgImage: baseImage.cgImage!, scale: 1, orientation: .right)
+
+        let expectation = expectation(description: "scan")
+        ReceiptScanner().scan(image: rotated) { result in
+            switch result {
+            case .success(let strings):
+                XCTAssertTrue(strings.contains(where: { $0.contains(text) }))
+            case .failure(let error):
+                XCTFail("Scanning failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+#else
+        throw XCTSkip("Requires iOS")
+#endif
+    }
 }


### PR DESCRIPTION
## Summary
- convert UIImage orientation to CGImagePropertyOrientation
- pass orientation to VNImageRequestHandler
- add test for OCR on rotated images (skipped on non-iOS platforms)

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_683fb56d90108320ad2f17672a0383a3