### PR TITLE
Handle loadPersistentStores error

### DIFF
--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -15,21 +15,38 @@ extension Expense {
 }
 
 public struct PersistenceController {
-    public static let shared = PersistenceController()
+    public static let shared: PersistenceController = {
+        do {
+            return try PersistenceController()
+        } catch {
+            fatalError("Unresolved error \(error)")
+        }
+    }()
     public let container: NSPersistentContainer
 
-    public init(inMemory: Bool = false) {
+    public init(inMemory: Bool = false, storeURL: URL? = nil) throws {
         container = NSPersistentContainer(name: "ExpenseModel")
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        } else if let storeURL {
+            container.persistentStoreDescriptions.first?.url = storeURL
         }
-        container.loadPersistentStores { _, _ in }
+        var loadError: Error?
+        container.loadPersistentStores { _, error in
+            loadError = error
+            if let error {
+                print("Failed to load persistent stores: \(error)")
+            }
+        }
+        if let loadError {
+            throw loadError
+        }
     }
 }
 #else
 import Foundation
 
 public struct PersistenceController {
-    public init() {}
+    public init(inMemory: Bool = false, storeURL: URL? = nil) throws {}
 }
 #endif

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -6,4 +6,11 @@ final class ExpenseTrackerTests: XCTestCase {
         // Placeholder test to establish structure
         XCTAssertTrue(true)
     }
+
+#if canImport(CoreData)
+    func testInitializationFailsWithInvalidStoreURL() throws {
+        let invalidURL = URL(fileURLWithPath: "/invalid/path/store.sqlite")
+        XCTAssertThrowsError(try PersistenceController(storeURL: invalidURL))
+    }
+#endif
 }


### PR DESCRIPTION
## Summary
- expose initialization failure from `PersistenceController`
- log load errors and throw
- add a test for invalid store URL

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fb56e22048320a05db3284541155f