### PR TITLE
Inject managed object context into ExpensesChartView

### DIFF
--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -1,12 +1,19 @@
 import SwiftUI
+import DataVisualizer
+import ExpenseStore
+import CoreData
 
 struct ContentView: View {
+    @Environment(\.managedObjectContext) private var context
+
     var body: some View {
-        Text("Hello, SwiftUI!")
+        ExpensesChartView(context: context)
             .padding()
     }
 }
 
 #Preview {
-    ContentView()
+    let context = PersistenceController.shared.container.viewContext
+    return ContentView()
+        .environment(\.managedObjectContext, context)
 }

--- a/ExpenseTracker/ExpenseTrackerApp.swift
+++ b/ExpenseTracker/ExpenseTrackerApp.swift
@@ -1,10 +1,13 @@
 import SwiftUI
+import ExpenseStore
 
 @main
 struct ExpenseTrackerApp: App {
+    let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,6 @@ let package = Package(
             dependencies: ["ReceiptScanner", "ExpenseStore", "DataVisualizer"]),
         .testTarget(
             name: "ExpenseTrackerTests",
-            dependencies: ["ExpenseTracker"]),
+            dependencies: ["ExpenseTracker", "DataVisualizer", "ExpenseStore"]),
     ]
 )

--- a/Sources/DataVisualizer/DataVisualizer.swift
+++ b/Sources/DataVisualizer/DataVisualizer.swift
@@ -1,14 +1,22 @@
 #if canImport(SwiftUI) && canImport(CoreData)
 import SwiftUI
+import CoreData
 import ExpenseStore
 
 public struct ExpensesChartView: View {
-    @FetchRequest(
-        entity: Expense.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \Expense.date, ascending: true)]
-    ) private var expenses: FetchedResults<Expense>
+    @FetchRequest private var expenses: FetchedResults<Expense>
+    private let context: NSManagedObjectContext
 
-    public init() {}
+    public init(context: NSManagedObjectContext) {
+        self.context = context
+        _expenses = FetchRequest(
+            entity: Expense.entity(),
+            sortDescriptors: [NSSortDescriptor(keyPath: \Expense.date, ascending: true)],
+            animation: .default,
+            predicate: nil,
+            managedObjectContext: context
+        )
+    }
 
     public var body: some View {
         VStack {
@@ -20,6 +28,6 @@ public struct ExpensesChartView: View {
 import Foundation
 
 public struct ExpensesChartView {
-    public init() {}
+    public init(context: Any? = nil) {}
 }
 #endif

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -1,9 +1,17 @@
 import XCTest
+import DataVisualizer
+import ExpenseStore
+
 @testable import ExpenseTracker
 
 final class ExpenseTrackerTests: XCTestCase {
-    func testExample() throws {
-        // Placeholder test to establish structure
+    func testChartViewInitialization() throws {
+        #if canImport(CoreData)
+        let context = PersistenceController(inMemory: true).container.viewContext
+        _ = ExpensesChartView(context: context)
+        #else
+        _ = ExpensesChartView(context: nil)
+        #endif
         XCTAssertTrue(true)
     }
 }


### PR DESCRIPTION
## Summary
- allow passing an `NSManagedObjectContext` into `ExpensesChartView`
- use `ExpensesChartView` in the demo SwiftUI app
- expose the persistence controller in the app delegate
- adjust package layout for tests and update tests to construct the view with a context

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fb56f40ac8320b5efbcf2bb757ffb