### PR TITLE
Add conditional tests for scanning and persistence

### DIFF
--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -1,0 +1,12 @@
+#if canImport(SwiftUI)
+import XCTest
+import SwiftUI
+@testable import DataVisualizer
+
+final class ExpensesChartViewTests: XCTestCase {
+    func testViewInitialization() {
+        let view = ExpensesChartView()
+        XCTAssertNotNil(view)
+    }
+}
+#endif

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -1,0 +1,33 @@
+#if canImport(CoreData)
+import XCTest
+import CoreData
+@testable import ExpenseStore
+
+final class PersistenceControllerTests: XCTestCase {
+    func testCRUDOperations() throws {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+
+        let expense = Expense(context: context)
+        expense.id = UUID()
+        expense.title = "Lunch"
+        expense.amount = 9.99
+        expense.date = Date()
+
+        try context.save()
+
+        let request: NSFetchRequest<Expense> = Expense.fetchRequest()
+        var results = try context.fetch(request)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.title, "Lunch")
+
+        if let fetchedExpense = results.first {
+            context.delete(fetchedExpense)
+            try context.save()
+        }
+
+        results = try context.fetch(request)
+        XCTAssertEqual(results.count, 0)
+    }
+}
+#endif

--- a/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
+++ b/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit) && canImport(Vision)
+import XCTest
+import UIKit
+@testable import ReceiptScanner
+
+final class ReceiptScannerTests: XCTestCase {
+    func testScanExtractsText() {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 50))
+        let image = renderer.image { ctx in
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 20)
+            ]
+            let text = NSString(string: "Total $5")
+            text.draw(at: CGPoint(x: 10, y: 10), withAttributes: attributes)
+        }
+
+        let expectation = expectation(description: "scanning")
+        let scanner = ReceiptScanner()
+        scanner.scan(image: image) { result in
+            switch result {
+            case .success(let texts):
+                XCTAssertTrue(texts.contains { $0.contains("Total") })
+            case .failure(let error):
+                XCTFail("Scan failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add iOS-only tests for `ReceiptScanner`
- add Core Data CRUD tests for `PersistenceController`
- add a simple SwiftUI view test for `ExpensesChartView`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fb5711fd0832096a3cef31dba65a6