### PR TITLE
Support extra fields in Expense entity

### DIFF
--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -6,6 +6,9 @@ public class Expense: NSManagedObject {
     @NSManaged public var title: String
     @NSManaged public var amount: Double
     @NSManaged public var date: Date
+    @NSManaged public var category: String?
+    @NSManaged public var tags: [String]?
+    @NSManaged public var notes: String?
 }
 
 extension Expense {
@@ -19,11 +22,69 @@ public struct PersistenceController {
     public let container: NSPersistentContainer
 
     public init(inMemory: Bool = false) {
-        container = NSPersistentContainer(name: "ExpenseModel")
+        let model = Self.managedObjectModel()
+        container = NSPersistentContainer(name: "ExpenseModel", managedObjectModel: model)
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }
         container.loadPersistentStores { _, _ in }
+    }
+
+    private static func managedObjectModel() -> NSManagedObjectModel {
+        let model = NSManagedObjectModel()
+        let entity = NSEntityDescription()
+        entity.name = "Expense"
+        entity.managedObjectClassName = NSStringFromClass(Expense.self)
+
+        var properties: [NSPropertyDescription] = []
+
+        let id = NSAttributeDescription()
+        id.name = "id"
+        id.attributeType = .UUIDAttributeType
+        id.isOptional = false
+        properties.append(id)
+
+        let title = NSAttributeDescription()
+        title.name = "title"
+        title.attributeType = .stringAttributeType
+        title.isOptional = false
+        properties.append(title)
+
+        let amount = NSAttributeDescription()
+        amount.name = "amount"
+        amount.attributeType = .doubleAttributeType
+        amount.isOptional = false
+        properties.append(amount)
+
+        let date = NSAttributeDescription()
+        date.name = "date"
+        date.attributeType = .dateAttributeType
+        date.isOptional = false
+        properties.append(date)
+
+        let category = NSAttributeDescription()
+        category.name = "category"
+        category.attributeType = .stringAttributeType
+        category.isOptional = true
+        properties.append(category)
+
+        let tags = NSAttributeDescription()
+        tags.name = "tags"
+        tags.attributeType = .transformableAttributeType
+        tags.attributeValueClassName = NSStringFromClass(NSArray.self)
+        tags.valueTransformerName = NSValueTransformerName.secureUnarchiveFromDataTransformerName.rawValue
+        tags.isOptional = true
+        properties.append(tags)
+
+        let notes = NSAttributeDescription()
+        notes.name = "notes"
+        notes.attributeType = .stringAttributeType
+        notes.isOptional = true
+        properties.append(notes)
+
+        entity.properties = properties
+        model.entities = [entity]
+        return model
     }
 }
 #else

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -13,13 +13,21 @@ final class PersistenceControllerTests: XCTestCase {
         expense.title = "Lunch"
         expense.amount = 9.99
         expense.date = Date()
+        expense.category = "Food"
+        expense.tags = ["meal", "lunch"]
+        expense.notes = "Paid by cash"
 
         try context.save()
 
         let request: NSFetchRequest<Expense> = Expense.fetchRequest()
         var results = try context.fetch(request)
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first?.title, "Lunch")
+        if let first = results.first {
+            XCTAssertEqual(first.title, "Lunch")
+            XCTAssertEqual(first.category, "Food")
+            XCTAssertEqual(first.tags ?? [], ["meal", "lunch"])
+            XCTAssertEqual(first.notes, "Paid by cash")
+        }
 
         if let fetchedExpense = results.first {
             context.delete(fetchedExpense)


### PR DESCRIPTION
## Summary
- extend `Expense` with optional `category`, `tags`, and `notes`
- create Core Data model in code to include the new properties
- update persistence tests for the new fields

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fbc557814832090ac68370c6e1003