### PR TITLE
Add receipt data parsing

### DIFF
--- a/Sources/ReceiptScanner/ReceiptScanner.swift
+++ b/Sources/ReceiptScanner/ReceiptScanner.swift
@@ -1,12 +1,27 @@
-#if os(iOS)
+// Common imports
 import Foundation
+
+public struct ReceiptData {
+    public var total: Double?
+    public var date: Date?
+    public var vendor: String?
+    public var lines: [String]
+    public init(total: Double? = nil, date: Date? = nil, vendor: String? = nil, lines: [String]) {
+        self.total = total
+        self.date = date
+        self.vendor = vendor
+        self.lines = lines
+    }
+}
+
+#if os(iOS)
 import Vision
 import UIKit
 
 public class ReceiptScanner {
     public init() {}
 
-    public func scan(image: UIImage, completion: @escaping (Result<[String], Error>) -> Void) {
+    public func scan(image: UIImage, completion: @escaping (Result<ReceiptData, Error>) -> Void) {
         guard let cgImage = image.cgImage else {
             completion(.failure(ScannerError.invalidImage))
             return
@@ -20,7 +35,7 @@ public class ReceiptScanner {
 
             let texts = request.results?
                 .compactMap { ($0 as? VNRecognizedTextObservation)?.topCandidates(1).first?.string } ?? []
-            completion(.success(texts))
+            completion(.success(self.parseReceiptData(from: texts)))
         }
         request.recognitionLevel = .accurate
         let orientation = CGImagePropertyOrientation(image.imageOrientation)
@@ -32,6 +47,42 @@ public class ReceiptScanner {
                 completion(.failure(error))
             }
         }
+    }
+
+    private func parseReceiptData(from lines: [String]) -> ReceiptData {
+        var data = ReceiptData(lines: lines)
+        data.vendor = lines.first?.trimmingCharacters(in: .whitespaces)
+
+        let totalPattern = "(?i)total\\s*\\$?([0-9]+(?:\\.[0-9]{2})?)"
+        for line in lines {
+            if let match = line.range(of: totalPattern, options: .regularExpression) {
+                if let amountRange = line.range(of: "[0-9]+(?:\\.[0-9]{2})?", options: .regularExpression, range: match) {
+                    let amountStr = String(line[amountRange])
+                    data.total = Double(amountStr)
+                    break
+                }
+            }
+        }
+
+        let datePatterns = ["\\b\\d{1,2}/\\d{1,2}/\\d{2,4}\\b", "\\b\\d{4}-\\d{2}-\\d{2}\\b"]
+        outer: for line in lines {
+            for pattern in datePatterns {
+                if let range = line.range(of: pattern, options: .regularExpression) {
+                    let dateStr = String(line[range])
+                    let fmts = ["MM/dd/yyyy", "MM/dd/yy", "yyyy-MM-dd", "dd/MM/yyyy", "dd/MM/yy"]
+                    let formatter = DateFormatter()
+                    formatter.locale = Locale(identifier: "en_US_POSIX")
+                    for f in fmts {
+                        formatter.dateFormat = f
+                        if let d = formatter.date(from: dateStr) {
+                            data.date = d
+                            break outer
+                        }
+                    }
+                }
+            }
+        }
+        return data
     }
 
     public enum ScannerError: Error {
@@ -59,7 +110,7 @@ import Foundation
 
 public class ReceiptScanner {
     public init() {}
-    public func scan(imageData: Data, completion: @escaping (Result<[String], Error>) -> Void) {
+    public func scan(imageData: Data, completion: @escaping (Result<ReceiptData, Error>) -> Void) {
         completion(.failure(ScannerError.unsupportedPlatform))
     }
 

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -32,8 +32,8 @@ final class ExpenseTrackerTests: XCTestCase {
         let expectation = expectation(description: "scan")
         ReceiptScanner().scan(image: rotated) { result in
             switch result {
-            case .success(let strings):
-                XCTAssertTrue(strings.contains(where: { $0.contains(text) }))
+            case .success(let data):
+                XCTAssertTrue(data.lines.contains(where: { $0.contains(text) }))
             case .failure(let error):
                 XCTFail("Scanning failed: \(error)")
             }

--- a/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
+++ b/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
@@ -18,8 +18,9 @@ final class ReceiptScannerTests: XCTestCase {
         let scanner = ReceiptScanner()
         scanner.scan(image: image) { result in
             switch result {
-            case .success(let texts):
-                XCTAssertTrue(texts.contains { $0.contains("Total") })
+            case .success(let data):
+                XCTAssertTrue(data.lines.contains { $0.contains("Total") })
+                XCTAssertEqual(data.total, 5)
             case .failure(let error):
                 XCTFail("Scan failed with error: \(error)")
             }


### PR DESCRIPTION
## Summary
- parse recognized text into totals, dates, and vendor names
- return new `ReceiptData` struct from `ReceiptScanner`
- update tests to expect parsed receipt data

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_683fbc58ca208320900f932e5b0a2c53