### PR TITLE
Enhance receipt scanning

### DIFF
--- a/Sources/ReceiptScanner/ReceiptScanner.swift
+++ b/Sources/ReceiptScanner/ReceiptScanner.swift
@@ -2,35 +2,110 @@
 import Foundation
 import Vision
 import UIKit
+import CoreImage
 
 public class ReceiptScanner {
     public init() {}
 
-    public func scan(image: UIImage, completion: @escaping (Result<[String], Error>) -> Void) {
+    /// Detect the receipt region using Vision rectangles or crop using a manual rect.
+    public func cropReceipt(in image: UIImage, rect: CGRect? = nil, completion: @escaping (UIImage?) -> Void) {
         guard let cgImage = image.cgImage else {
+            completion(nil)
+            return
+        }
+
+        if let manual = rect {
+            let scaled = CGRect(x: manual.origin.x * image.scale,
+                                y: manual.origin.y * image.scale,
+                                width: manual.width * image.scale,
+                                height: manual.height * image.scale)
+            if let cropped = cgImage.cropping(to: scaled) {
+                completion(UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation))
+            } else {
+                completion(nil)
+            }
+            return
+        }
+
+        let request = VNDetectRectanglesRequest { req, _ in
+            guard let rectObs = (req.results as? [VNRectangleObservation])?.first else {
+                completion(nil)
+                return
+            }
+
+            let width = CGFloat(cgImage.width)
+            let height = CGFloat(cgImage.height)
+            let bounding = rectObs.boundingBox
+            let cropRect = CGRect(x: bounding.origin.x * width,
+                                  y: (1 - bounding.origin.y - bounding.height) * height,
+                                  width: bounding.width * width,
+                                  height: bounding.height * height)
+            if let cropped = cgImage.cropping(to: cropRect) {
+                completion(UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation))
+            } else {
+                completion(nil)
+            }
+        }
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: CGImagePropertyOrientation(image.imageOrientation))
+        DispatchQueue.global().async {
+            try? handler.perform([request])
+        }
+    }
+
+    private func preprocess(_ image: UIImage) -> UIImage {
+        guard let ciImage = CIImage(image: image) else { return image }
+        let mono = ciImage.applyingFilter("CIPhotoEffectMono")
+        let contrasted = mono.applyingFilter("CIColorControls", parameters: ["inputContrast": 1.5])
+        let context = CIContext()
+        if let cg = context.createCGImage(contrasted, from: contrasted.extent) {
+            return UIImage(cgImage: cg, scale: image.scale, orientation: image.imageOrientation)
+        }
+        return image
+    }
+
+    public func scan(image: UIImage, cropRect: CGRect? = nil, preprocess: Bool = false, completion: @escaping (Result<[String], Error>) -> Void) {
+        guard let _ = image.cgImage else {
             completion(.failure(ScannerError.invalidImage))
             return
         }
 
-        let request = VNRecognizeTextRequest { request, error in
-            if let error = error {
-                completion(.failure(error))
+        let performScan: (UIImage) -> Void = { target in
+            guard let cg = target.cgImage else {
+                completion(.failure(ScannerError.invalidImage))
                 return
             }
 
-            let texts = request.results?
-                .compactMap { ($0 as? VNRecognizedTextObservation)?.topCandidates(1).first?.string } ?? []
-            completion(.success(texts))
-        }
-        request.recognitionLevel = .accurate
-        let orientation = CGImagePropertyOrientation(image.imageOrientation)
-        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: orientation)
-        DispatchQueue.global().async {
-            do {
-                try handler.perform([request])
-            } catch {
-                completion(.failure(error))
+            let request = VNRecognizeTextRequest { request, error in
+                if let error = error {
+                    completion(.failure(error))
+                    return
+                }
+
+                let texts = request.results?
+                    .compactMap { ($0 as? VNRecognizedTextObservation)?.topCandidates(1).first?.string } ?? []
+                completion(.success(texts))
             }
+            request.recognitionLevel = .accurate
+            let orientation = CGImagePropertyOrientation(target.imageOrientation)
+            let handler = VNImageRequestHandler(cgImage: cg, orientation: orientation)
+            DispatchQueue.global().async {
+                do {
+                    try handler.perform([request])
+                } catch {
+                    completion(.failure(error))
+                }
+            }
+        }
+
+        let startingImage = preprocess ? self.preprocess(image) : image
+
+        if cropRect != nil {
+            cropReceipt(in: startingImage, rect: cropRect) { cropped in
+                performScan(cropped ?? startingImage)
+            }
+        } else {
+            performScan(startingImage)
         }
     }
 
@@ -59,7 +134,11 @@ import Foundation
 
 public class ReceiptScanner {
     public init() {}
-    public func scan(imageData: Data, completion: @escaping (Result<[String], Error>) -> Void) {
+    public func cropReceipt(in imageData: Data, rect: CGRect? = nil, completion: @escaping (Data?) -> Void) {
+        completion(nil)
+    }
+
+    public func scan(imageData: Data, cropRect: CGRect? = nil, preprocess: Bool = false, completion: @escaping (Result<[String], Error>) -> Void) {
         completion(.failure(ScannerError.unsupportedPlatform))
     }
 

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -30,7 +30,7 @@ final class ExpenseTrackerTests: XCTestCase {
         let rotated = UIImage(cgImage: baseImage.cgImage!, scale: 1, orientation: .right)
 
         let expectation = expectation(description: "scan")
-        ReceiptScanner().scan(image: rotated) { result in
+        ReceiptScanner().scan(image: rotated, preprocess: true) { result in
             switch result {
             case .success(let strings):
                 XCTAssertTrue(strings.contains(where: { $0.contains(text) }))

--- a/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
+++ b/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
@@ -27,5 +27,35 @@ final class ReceiptScannerTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5)
     }
+
+    func testScanWithCropAndPreprocess() {
+        let size = CGSize(width: 300, height: 150)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            UIColor.black.setFill()
+            ctx.fill(CGRect(x: 50, y: 40, width: 200, height: 60))
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 25),
+                .foregroundColor: UIColor.white
+            ]
+            NSString(string: "Subtotal").draw(at: CGPoint(x: 60, y: 55), withAttributes: attributes)
+        }
+
+        let crop = CGRect(x: 50, y: 40, width: 200, height: 60)
+        let expectation = expectation(description: "scanning")
+        let scanner = ReceiptScanner()
+        scanner.scan(image: image, cropRect: crop, preprocess: true) { result in
+            switch result {
+            case .success(let texts):
+                XCTAssertTrue(texts.contains { $0.contains("Subtotal") })
+            case .failure(let error):
+                XCTFail("Scan failed with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- add cropping and preprocessing utilities to `ReceiptScanner`
- test manual cropping & preprocessing
- test scanning rotated images with preprocessing

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fbc5a272483209d28a601a88ce086