### PR TITLE
Add expense list and receipt capture views with improved charts

### DIFF
--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -7,13 +7,30 @@ struct ContentView: View {
     @Environment(\.managedObjectContext) private var context
 
     var body: some View {
-        ExpensesChartView(context: context)
-            .padding()
+        TabView {
+            NavigationView { ExpensesChartView(context: context) }
+                .tabItem { Label("Charts", systemImage: "chart.bar") }
+
+            NavigationView { ExpenseListView() }
+                .environment(\.managedObjectContext, context)
+                .tabItem { Label("Expenses", systemImage: "list.bullet") }
+
+            NavigationView { ReceiptCaptureView() }
+                .tabItem { Label("Scan", systemImage: "camera") }
+        }
     }
 }
 
 #Preview {
-    let context = PersistenceController.shared.container.viewContext
-    return ContentView()
-        .environment(\.managedObjectContext, context)
+    let controller = PersistenceController(inMemory: true)
+    let context = controller.container.viewContext
+    for i in 0..<5 {
+        let exp = Expense(context: context)
+        exp.id = UUID()
+        exp.title = "Sample \(i)"
+        exp.amount = Double.random(in: 5...50)
+        exp.date = Calendar.current.date(byAdding: .month, value: -i, to: Date())!
+    }
+    try? context.save()
+    return ContentView().environment(\.managedObjectContext, context)
 }

--- a/ExpenseTracker/ExpenseListView.swift
+++ b/ExpenseTracker/ExpenseListView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import ExpenseStore
+import CoreData
+
+struct ExpenseListView: View {
+    @Environment(\.managedObjectContext) private var context
+    @FetchRequest(
+        entity: Expense.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Expense.date, ascending: false)],
+        animation: .default
+    ) private var fetchedExpenses: FetchedResults<Expense>
+    @State private var searchText: String = ""
+    @State private var sortOption: SortOption = .date
+
+    enum SortOption: String, CaseIterable, Identifiable {
+        case date = "Date"
+        case amount = "Amount"
+        var id: String { rawValue }
+    }
+
+    private var expenses: [Expense] {
+        var filtered = fetchedExpenses.filter { searchText.isEmpty || $0.title.localizedCaseInsensitiveContains(searchText) }
+        switch sortOption {
+        case .date:
+            filtered.sort { $0.date > $1.date }
+        case .amount:
+            filtered.sort { $0.amount > $1.amount }
+        }
+        return filtered
+    }
+
+    var body: some View {
+        VStack {
+            Picker("Sort", selection: $sortOption) {
+                ForEach(SortOption.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding([.horizontal, .top])
+
+            List {
+                ForEach(expenses, id: \.id) { expense in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(expense.title)
+                            Text(expense.date, style: .date)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(expense.amount, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                    }
+                }
+            }
+            .searchable(text: $searchText)
+        }
+        .navigationTitle("Expenses")
+    }
+}
+
+#Preview {
+    let controller = PersistenceController(inMemory: true)
+    let viewContext = controller.container.viewContext
+    for i in 0..<5 {
+        let exp = Expense(context: viewContext)
+        exp.id = UUID()
+        exp.title = "Item \(i)"
+        exp.amount = Double.random(in: 5...100)
+        exp.date = Calendar.current.date(byAdding: .day, value: -i, to: Date())!
+    }
+    try? viewContext.save()
+    return NavigationView { ExpenseListView().environment(\.managedObjectContext, viewContext) }
+}

--- a/ExpenseTracker/ReceiptCaptureView.swift
+++ b/ExpenseTracker/ReceiptCaptureView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import ReceiptScanner
+
+struct ReceiptCaptureView: View {
+    @State private var showPicker = false
+    @State private var image: UIImage?
+    @State private var recognizedLines: [String] = []
+    @State private var isScanning = false
+    @State private var pickerSource: UIImagePickerController.SourceType = .camera
+
+    var body: some View {
+        VStack {
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 200)
+            }
+            if isScanning {
+                ProgressView()
+            }
+            List {
+                ForEach(recognizedLines.indices, id: \.self) { index in
+                    TextField("Line", text: Binding(
+                        get: { recognizedLines[index] },
+                        set: { recognizedLines[index] = $0 }
+                    ))
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button {
+                    pickerSource = .camera
+                    showPicker = true
+                } label: {
+                    Label("Camera", systemImage: "camera")
+                }
+                Button {
+                    pickerSource = .photoLibrary
+                    showPicker = true
+                } label: {
+                    Label("Photos", systemImage: "photo.on.rectangle")
+                }
+            }
+        }
+        .sheet(isPresented: $showPicker) {
+            ImagePicker(sourceType: pickerSource) { uiImage in
+                self.image = uiImage
+                scan(uiImage)
+            }
+        }
+    }
+
+    private func scan(_ uiImage: UIImage) {
+        isScanning = true
+        ReceiptScanner().scan(image: uiImage) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let lines):
+                    self.recognizedLines = lines
+                case .failure:
+                    self.recognizedLines = []
+                }
+                self.isScanning = false
+            }
+        }
+    }
+}
+
+private struct ImagePicker: UIViewControllerRepresentable {
+    var sourceType: UIImagePickerController.SourceType
+    var completion: (UIImage) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = sourceType
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: ImagePicker
+        init(_ parent: ImagePicker) { self.parent = parent }
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.completion(image)
+            }
+            picker.dismiss(animated: true)
+        }
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}
+
+#Preview {
+    NavigationView { ReceiptCaptureView() }
+}

--- a/Sources/DataVisualizer/DataVisualizer.swift
+++ b/Sources/DataVisualizer/DataVisualizer.swift
@@ -7,21 +7,63 @@ public struct ExpensesChartView: View {
     @FetchRequest private var expenses: FetchedResults<Expense>
     private let context: NSManagedObjectContext
 
-    public init(context: NSManagedObjectContext) {
-        self.context = context
+    public init(context: NSManagedObjectContext? = nil) {
+        if let ctx = context {
+            self.context = ctx
+        } else {
+            self.context = PersistenceController(inMemory: true).container.viewContext
+        }
         _expenses = FetchRequest(
             entity: Expense.entity(),
             sortDescriptors: [NSSortDescriptor(keyPath: \Expense.date, ascending: true)],
             animation: .default,
             predicate: nil,
-            managedObjectContext: context
+            managedObjectContext: self.context
         )
+    }
+
+    struct MonthTotal: Identifiable {
+        let id = UUID()
+        let month: Date
+        let total: Double
+    }
+
+    private var monthlyTotals: [MonthTotal] {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: expenses) { expense -> Date in
+            calendar.date(from: calendar.dateComponents([.year, .month], from: expense.date)) ?? expense.date
+        }
+        return grouped.map { (month, expenses) in
+            MonthTotal(month: month, total: expenses.reduce(0) { $0 + $1.amount })
+        }
+        .sorted { $0.month < $1.month }
+    }
+
+    private var maxTotal: Double {
+        monthlyTotals.map(\.total).max() ?? 0
+    }
+
+    private var monthFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "MMM"
+        return df
     }
 
     public var body: some View {
         VStack {
-            Text("Expenses: \(expenses.count)")
+            HStack(alignment: .bottom, spacing: 4) {
+                ForEach(monthlyTotals) { item in
+                    VStack {
+                        Capsule()
+                            .fill(Color.accentColor)
+                            .frame(height: maxTotal > 0 ? CGFloat(item.total / maxTotal) * 150 : 0)
+                        Text(monthFormatter.string(from: item.month))
+                            .font(.caption2)
+                    }
+                }
+            }
         }
+        .padding()
     }
 }
 #else


### PR DESCRIPTION
## Summary
- show month-based bar chart in `ExpensesChartView`
- list expenses with sorting and searching in `ExpenseListView`
- capture receipts using camera or library with OCR in `ReceiptCaptureView`
- integrate new views using a `TabView`

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_683fbc5b4e1c83208679aeb8dc7521eb