### PR TITLE
Add basic user authentication and CloudKit scaffolding

### DIFF
--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -2,13 +2,19 @@ import SwiftUI
 import DataVisualizer
 import ExpenseStore
 import CoreData
+import UserAuth
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var context
+    @StateObject private var userManager = UserManager()
 
     var body: some View {
-        ExpensesChartView(context: context)
-            .padding()
+        if userManager.currentUser != nil {
+            ExpensesChartView(context: context)
+                .padding()
+        } else {
+            SignInView(manager: userManager)
+        }
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,17 +11,19 @@ let package = Package(
     products: [
         .library(name: "ReceiptScanner", targets: ["ReceiptScanner"]),
         .library(name: "ExpenseStore", targets: ["ExpenseStore"]),
-        .library(name: "DataVisualizer", targets: ["DataVisualizer"])
+        .library(name: "DataVisualizer", targets: ["DataVisualizer"]),
+        .library(name: "UserAuth", targets: ["UserAuth"])
     ],
     targets: [
         .target(name: "ReceiptScanner"),
         .target(name: "ExpenseStore"),
         .target(name: "DataVisualizer", dependencies: ["ExpenseStore"]),
+        .target(name: "UserAuth"),
         .executableTarget(
             name: "ExpenseTracker",
-            dependencies: ["ReceiptScanner", "ExpenseStore", "DataVisualizer"]),
+            dependencies: ["ReceiptScanner", "ExpenseStore", "DataVisualizer", "UserAuth"]),
         .testTarget(
             name: "ExpenseTrackerTests",
-            dependencies: ["ExpenseTracker", "DataVisualizer", "ExpenseStore"]),
+            dependencies: ["ExpenseTracker", "DataVisualizer", "ExpenseStore", "UserAuth"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ device) and press **Run**.
 - Connect an iPhone or iPad and select it as the target device in Xcode.
 - Ensure the deployment target of the project matches or is lower than your device's iOS version.
 
+## User Setup
+
+The app supports signing in with Apple or entering a local name. When building for iOS, enable the **Sign in with Apple** capability in the Xcode project if you would like to use Apple's authentication. A simple local sign-in flow is also provided for simulator testing.
+
+To synchronize expenses across devices, enable the **iCloud** capability with CloudKit. A lightweight `CloudSyncManager` is available in the `ExpenseStore` module that can be expanded to push and fetch records.
+
 ## Contributing and Testing
 
 Contributions are welcome! Fork the repository, create a feature branch, and open a pull request.

--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -1,0 +1,26 @@
+#if canImport(CloudKit)
+import CloudKit
+import CoreData
+
+public class CloudSyncManager {
+    private let database: CKDatabase
+
+    public init(container: CKContainer = .default()) {
+        self.database = container.privateCloudDatabase
+    }
+
+    public func sync(expenses: [Expense], completion: @escaping (Error?) -> Void) {
+        // Placeholder for CloudKit syncing logic
+        completion(nil)
+    }
+}
+#else
+import Foundation
+
+public class CloudSyncManager {
+    public init() {}
+    public func sync(expenses: [Any], completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+}
+#endif

--- a/Sources/UserAuth/SignInView.swift
+++ b/Sources/UserAuth/SignInView.swift
@@ -1,0 +1,32 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct SignInView: View {
+    @ObservedObject private var manager: UserManager
+    @State private var name: String = ""
+
+    public init(manager: UserManager) {
+        self.manager = manager
+    }
+
+    public var body: some View {
+        VStack {
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .padding()
+            Button("Sign In") {
+                manager.signInLocally(name: name)
+            }
+#if canImport(AuthenticationServices)
+            SignInWithAppleButton(.signIn) { request in
+                request.requestedScopes = [.fullName]
+            } onCompletion: { _ in
+                manager.signInWithApple()
+            }
+            .signInWithAppleButtonStyle(.black)
+            .frame(height: 44)
+#endif
+        }
+    }
+}
+#endif

--- a/Sources/UserAuth/User.swift
+++ b/Sources/UserAuth/User.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct User: Identifiable, Codable {
+    public var id: String
+    public var name: String
+
+    public init(id: String = UUID().uuidString, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Sources/UserAuth/UserManager.swift
+++ b/Sources/UserAuth/UserManager.swift
@@ -1,0 +1,65 @@
+#if canImport(Combine)
+import Foundation
+import Combine
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
+
+public class UserManager: NSObject, ObservableObject {
+    @Published public private(set) var currentUser: User?
+
+    public override init() {}
+
+    public func signInLocally(name: String) {
+        currentUser = User(name: name)
+    }
+
+#if canImport(AuthenticationServices)
+    public func signInWithApple() {
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName]
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.performRequests()
+    }
+#endif
+
+    public func signOut() {
+        currentUser = nil
+    }
+}
+
+#if canImport(AuthenticationServices)
+extension UserManager: ASAuthorizationControllerDelegate {
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            let fullName = [credential.fullName?.givenName, credential.fullName?.familyName]
+                .compactMap { $0 }
+                .joined(separator: " ")
+            currentUser = User(id: credential.user, name: fullName)
+        }
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Authorization error: \(error)")
+    }
+}
+#endif
+
+#else
+import Foundation
+
+public class UserManager: NSObject {
+    public private(set) var currentUser: User?
+
+    public override init() {}
+
+    public func signInLocally(name: String) {
+        currentUser = User(name: name)
+    }
+
+    public func signOut() {
+        currentUser = nil
+    }
+}
+#endif

--- a/Tests/ExpenseTrackerTests/UserManagerTests.swift
+++ b/Tests/ExpenseTrackerTests/UserManagerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import UserAuth
+
+final class UserManagerTests: XCTestCase {
+    func testLocalSignInStoresUser() {
+        let manager = UserManager()
+        manager.signInLocally(name: "Alice")
+        XCTAssertEqual(manager.currentUser?.name, "Alice")
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserAuth` module with `User`, `UserManager`, and `SignInView`
- show the sign-in screen in `ContentView`
- introduce a stub `CloudSyncManager` for CloudKit in `ExpenseStore`
- document sign-in and CloudKit setup in the README
- include tests for `UserManager`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fbc5dc4c48320a746bbc64b41243e