### PR TITLE
Update license references to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ swift test
 
 ## License
 
-This project is distributed under a proprietary license. Usage requires a paid license agreement with an initial cost of $1000 and a $25 monthly fee per user. Unauthorized distribution or modification is prohibited.
+This project is licensed under the [MIT License](LICENSE).
+


### PR DESCRIPTION
## Summary
- switch README from proprietary license to MIT

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683fc05955d883208ee4db7b7bf11799