### PR TITLE
Refactor ReceiptScanner tests to embed image data

### DIFF
--- a/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
+++ b/Tests/ExpenseTrackerTests/ReceiptScannerTests.swift
@@ -4,6 +4,25 @@ import UIKit
 @testable import ReceiptScanner
 
 final class ReceiptScannerTests: XCTestCase {
+    // Base64 encoded 10x10 PNG with a single black pixel
+    static let pngData: Data = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAH0lEQVR4nGP8//8/A27AhEeO3tKMjIz4pNE8QlOnAQDnTwYRH1UVVAAAAABJRU5ErkJggg==")!
+
+    // Base64 encoded two page 3x3 TIFF
+    static let tiffData: Data = Data(base64Encoded:
+        "SUkqAAgAAAAKAAABBAABAAAAAwAAAAEBBAABAAAAAwAAAAIBAwADAAAAhgAAAAMBAwABAAAAAQAAAAYBAwABAAAAAgAAABEBBAABAAAAjAAAABUBAwABAAAAAwAAABYBBAABAAAAAwAAABcBBAABAAAAGwAAABwBAwABAAAAAQAAALgAAAAIAAgACAD///////////////////////////////////8AAAAAAAAAAABJSSoACAAAAAoAAAEEAAEAAAADAAAAAQEEAAEAAAADAAAAAgEDAAMAAAA2AQAAAwEDAAEAAAABAAAABgEDAAEAAAACAAAAEQEEAAEAAAA8AQAAFQEDAAEAAAADAAAAFgEEAAEAAAADAAAAFwEEAAEAAAAbAAAAHAEDAAEAAAABAAAAAAAAAAgACAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==")!
+
+    private func loadImage(_ name: String) -> UIImage {
+        switch name {
+        case "sample.png":
+            return UIImage(data: Self.pngData)!
+        case "multipage.tiff":
+            return UIImage(data: Self.tiffData)!
+        default:
+            fatalError("Unknown image \(name)")
+        }
+    }
+
     func testScanExtractsText() {
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 50))
         let image = renderer.image { ctx in
@@ -27,6 +46,12 @@ final class ReceiptScannerTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5)
+    }
+
+    func testMultiPageTiff() {
+        let image = loadImage("multipage.tiff")
+        XCTAssertEqual(image.size.width, 3)
+        XCTAssertEqual(image.size.height, 3)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- update `ReceiptScannerTests.swift` to embed PNG and TIFF image data as base64 constants
- decode these constants in `loadImage` for tests
- add a simple multi-page TIFF test

## Testing
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_683fc01711048320bc02414af4097f03