### PR TITLE
Add RecurrenceFrequency enum

### DIFF
--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -9,6 +9,14 @@ public class Expense: NSManagedObject {
     @NSManaged public var category: String?
     @NSManaged public var tags: [String]?
     @NSManaged public var notes: String?
+    @NSManaged @objc(frequency) private var frequencyRaw: String?
+}
+
+extension Expense {
+    public var frequency: RecurrenceFrequency? {
+        get { frequencyRaw.flatMap { RecurrenceFrequency(rawValue: $0) } }
+        set { frequencyRaw = newValue?.rawValue }
+    }
 }
 
 extension Expense {
@@ -81,6 +89,12 @@ public struct PersistenceController {
         notes.attributeType = .stringAttributeType
         notes.isOptional = true
         properties.append(notes)
+
+        let frequency = NSAttributeDescription()
+        frequency.name = "frequency"
+        frequency.attributeType = .stringAttributeType
+        frequency.isOptional = true
+        properties.append(frequency)
 
         entity.properties = properties
         model.entities = [entity]

--- a/Sources/ExpenseStore/RecurrenceFrequency.swift
+++ b/Sources/ExpenseStore/RecurrenceFrequency.swift
@@ -1,0 +1,6 @@
+public enum RecurrenceFrequency: String, CaseIterable, Codable {
+    case daily
+    case weekly
+    case monthly
+    case yearly
+}

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -16,6 +16,7 @@ final class PersistenceControllerTests: XCTestCase {
         expense.category = "Food"
         expense.tags = ["meal", "lunch"]
         expense.notes = "Paid by cash"
+        expense.frequency = .weekly
 
         try context.save()
 
@@ -27,6 +28,7 @@ final class PersistenceControllerTests: XCTestCase {
             XCTAssertEqual(first.category, "Food")
             XCTAssertEqual(first.tags ?? [], ["meal", "lunch"])
             XCTAssertEqual(first.notes, "Paid by cash")
+            XCTAssertEqual(first.frequency, .weekly)
         }
 
         if let fetchedExpense = results.first {


### PR DESCRIPTION
## Summary
- introduce `RecurrenceFrequency` enum
- store frequency in `Expense` Core Data entity
- test CRUD with `frequency`

## Testing
- `swift test`
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_683fc05b1b94832082af7a4c1e44af13