### PR TITLE
Add recurring expense & budget helpers

### DIFF
--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -11,6 +11,31 @@ public class Expense: NSManagedObject {
     @NSManaged public var notes: String?
 }
 
+public class RecurringExpense: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var title: String
+    @NSManaged public var amount: Double
+    @NSManaged public var frequency: String?
+}
+
+extension RecurringExpense {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<RecurringExpense> {
+        NSFetchRequest<RecurringExpense>(entityName: "RecurringExpense")
+    }
+}
+
+public class Budget: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var category: String
+    @NSManaged public var limit: Double
+}
+
+extension Budget {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Budget> {
+        NSFetchRequest<Budget>(entityName: "Budget")
+    }
+}
+
 extension Expense {
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Expense> {
         NSFetchRequest<Expense>(entityName: "Expense")
@@ -32,9 +57,9 @@ public struct PersistenceController {
 
     private static func managedObjectModel() -> NSManagedObjectModel {
         let model = NSManagedObjectModel()
-        let entity = NSEntityDescription()
-        entity.name = "Expense"
-        entity.managedObjectClassName = NSStringFromClass(Expense.self)
+        let expenseEntity = NSEntityDescription()
+        expenseEntity.name = "Expense"
+        expenseEntity.managedObjectClassName = NSStringFromClass(Expense.self)
 
         var properties: [NSPropertyDescription] = []
 
@@ -82,15 +107,135 @@ public struct PersistenceController {
         notes.isOptional = true
         properties.append(notes)
 
-        entity.properties = properties
-        model.entities = [entity]
+        expenseEntity.properties = properties
+
+        // RecurringExpense entity
+        let recEntity = NSEntityDescription()
+        recEntity.name = "RecurringExpense"
+        recEntity.managedObjectClassName = NSStringFromClass(RecurringExpense.self)
+
+        var recProps: [NSPropertyDescription] = []
+
+        let recId = NSAttributeDescription()
+        recId.name = "id"
+        recId.attributeType = .UUIDAttributeType
+        recId.isOptional = false
+        recProps.append(recId)
+
+        let recTitle = NSAttributeDescription()
+        recTitle.name = "title"
+        recTitle.attributeType = .stringAttributeType
+        recTitle.isOptional = false
+        recProps.append(recTitle)
+
+        let recAmount = NSAttributeDescription()
+        recAmount.name = "amount"
+        recAmount.attributeType = .doubleAttributeType
+        recAmount.isOptional = false
+        recProps.append(recAmount)
+
+        let recFreq = NSAttributeDescription()
+        recFreq.name = "frequency"
+        recFreq.attributeType = .stringAttributeType
+        recFreq.isOptional = true
+        recProps.append(recFreq)
+
+        recEntity.properties = recProps
+
+        // Budget entity
+        let budEntity = NSEntityDescription()
+        budEntity.name = "Budget"
+        budEntity.managedObjectClassName = NSStringFromClass(Budget.self)
+
+        var budProps: [NSPropertyDescription] = []
+
+        let budId = NSAttributeDescription()
+        budId.name = "id"
+        budId.attributeType = .UUIDAttributeType
+        budId.isOptional = false
+        budProps.append(budId)
+
+        let budCategory = NSAttributeDescription()
+        budCategory.name = "category"
+        budCategory.attributeType = .stringAttributeType
+        budCategory.isOptional = false
+        budProps.append(budCategory)
+
+        let budLimit = NSAttributeDescription()
+        budLimit.name = "limit"
+        budLimit.attributeType = .doubleAttributeType
+        budLimit.isOptional = false
+        budProps.append(budLimit)
+
+        budEntity.properties = budProps
+
+        model.entities = [expenseEntity, recEntity, budEntity]
         return model
+    }
+
+    // MARK: - Helper CRUD
+
+    @discardableResult
+    public func addRecurringExpense(title: String, amount: Double, frequency: String? = nil) -> RecurringExpense {
+        let context = container.viewContext
+        let item = RecurringExpense(context: context)
+        item.id = UUID()
+        item.title = title
+        item.amount = amount
+        item.frequency = frequency
+        try? context.save()
+        return item
+    }
+
+    public func deleteRecurringExpense(_ expense: RecurringExpense) {
+        let context = container.viewContext
+        context.delete(expense)
+        try? context.save()
+    }
+
+    @discardableResult
+    public func addBudget(category: String, limit: Double) -> Budget {
+        let context = container.viewContext
+        let item = Budget(context: context)
+        item.id = UUID()
+        item.category = category
+        item.limit = limit
+        try? context.save()
+        return item
+    }
+
+    public func deleteBudget(_ budget: Budget) {
+        let context = container.viewContext
+        context.delete(budget)
+        try? context.save()
     }
 }
 #else
 import Foundation
 
+public struct RecurringExpense {
+    public init() {}
+}
+
+public struct Budget {
+    public init() {}
+}
+
 public struct PersistenceController {
     public init() {}
+
+    @discardableResult
+    public func addRecurringExpense(title: String, amount: Double, frequency: String? = nil) -> RecurringExpense {
+        RecurringExpense()
+    }
+
+    public func deleteRecurringExpense(_ expense: RecurringExpense) {}
+
+    @discardableResult
+    public func addBudget(category: String, limit: Double) -> Budget {
+        Budget()
+    }
+
+    public func deleteBudget(_ budget: Budget) {}
 }
 #endif

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -37,5 +37,28 @@ final class PersistenceControllerTests: XCTestCase {
         results = try context.fetch(request)
         XCTAssertEqual(results.count, 0)
     }
+
+    func testRecurringAndBudgetHelpers() throws {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+
+        // Recurring Expense
+        let recurring = controller.addRecurringExpense(title: "Gym", amount: 30, frequency: "Monthly")
+        let recRequest: NSFetchRequest<RecurringExpense> = RecurringExpense.fetchRequest()
+        var recResults = try context.fetch(recRequest)
+        XCTAssertEqual(recResults.count, 1)
+        controller.deleteRecurringExpense(recurring)
+        recResults = try context.fetch(recRequest)
+        XCTAssertEqual(recResults.count, 0)
+
+        // Budget
+        let budget = controller.addBudget(category: "Food", limit: 200)
+        let budReq: NSFetchRequest<Budget> = Budget.fetchRequest()
+        var budResults = try context.fetch(budReq)
+        XCTAssertEqual(budResults.count, 1)
+        controller.deleteBudget(budget)
+        budResults = try context.fetch(budReq)
+        XCTAssertEqual(budResults.count, 0)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- expand ExpenseStore data model with `RecurringExpense` and `Budget` entities
- implement CRUD helpers in `PersistenceController`
- test helper functionality in `PersistenceControllerTests`

## Testing
- `swift test -l`
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_683fc0de2a608320aa4c594ef639053c