### PR TITLE
Fix receipt scan to access ReceiptData

### DIFF
--- a/ExpenseTracker/ReceiptCaptureView.swift
+++ b/ExpenseTracker/ReceiptCaptureView.swift
@@ -57,8 +57,8 @@ struct ReceiptCaptureView: View {
         ReceiptScanner().scan(image: uiImage) { result in
             DispatchQueue.main.async {
                 switch result {
-                case .success(let lines):
-                    self.recognizedLines = lines
+                case .success(let data):
+                    self.recognizedLines = data.lines
                 case .failure:
                     self.recognizedLines = []
                 }


### PR DESCRIPTION
## Summary
- grab lines from `ReceiptData` inside `ReceiptCaptureView`

## Testing
- `swift build`
- `swift test`

Unable to build the iOS target due to missing `xcodebuild`.

------
https://chatgpt.com/codex/tasks/task_e_683fc49a3e8883208c7f4b150d9348fb