### PR TITLE
Implement CloudKit sync

### DIFF
--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -2,16 +2,124 @@
 import CloudKit
 import CoreData
 
-public class CloudSyncManager {
-    private let database: CKDatabase
+public protocol CKDatabaseProtocol {
+    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
+}
 
-    public init(container: CKContainer = .default()) {
+extension CKDatabase: CKDatabaseProtocol {}
+
+public class CloudSyncManager {
+    private let database: CKDatabaseProtocol
+    private let context: NSManagedObjectContext
+
+    public init(container: CKContainer = .default(),
+                context: NSManagedObjectContext = PersistenceController.shared.container.viewContext) {
         self.database = container.privateCloudDatabase
+        self.context = context
+    }
+
+    public init(database: CKDatabaseProtocol,
+                context: NSManagedObjectContext) {
+        self.database = database
+        self.context = context
+    }
+
+    private func record(from expense: Expense) -> CKRecord {
+        let recordID = CKRecord.ID(recordName: expense.id.uuidString)
+        let record = CKRecord(recordType: "Expense", recordID: recordID)
+        record["title"] = expense.title as CKRecordValue
+        record["amount"] = expense.amount as CKRecordValue
+        record["date"] = expense.date as CKRecordValue
+        if let category = expense.category {
+            record["category"] = category as CKRecordValue
+        }
+        if let tags = expense.tags {
+            record["tags"] = tags as CKRecordValue
+        }
+        if let notes = expense.notes {
+            record["notes"] = notes as CKRecordValue
+        }
+        if let frequency = expense.frequency?.rawValue {
+            record["frequency"] = frequency as CKRecordValue
+        }
+        return record
+    }
+
+    private func update(_ expense: Expense, from record: CKRecord) {
+        expense.title = record["title"] as? String ?? expense.title
+        expense.amount = record["amount"] as? Double ?? expense.amount
+        expense.date = record["date"] as? Date ?? expense.date
+        expense.category = record["category"] as? String
+        expense.tags = record["tags"] as? [String]
+        expense.notes = record["notes"] as? String
+        if let raw = record["frequency"] as? String {
+            expense.frequency = RecurrenceFrequency(rawValue: raw)
+        } else {
+            expense.frequency = nil
+        }
+    }
+
+    private func merge(records: [CKRecord]) throws {
+        for record in records {
+            let id = UUID(uuidString: record.recordID.recordName) ?? UUID()
+            let request: NSFetchRequest<Expense> = Expense.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            if let existing = try context.fetch(request).first {
+                update(existing, from: record)
+            } else {
+                let newExpense = Expense(context: context)
+                newExpense.id = id
+                update(newExpense, from: record)
+            }
+        }
     }
 
     public func sync(expenses: [Expense], completion: @escaping (Error?) -> Void) {
-        // Placeholder for CloudKit syncing logic
-        completion(nil)
+        let records = expenses.map { record(from: $0) }
+        let group = DispatchGroup()
+        var capturedError: Error?
+        for record in records {
+            group.enter()
+            database.save(record) { _, error in
+                if capturedError == nil {
+                    capturedError = error
+                }
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            if let err = capturedError {
+                completion(err)
+                return
+            }
+            self.fetchUpdates(completion: completion)
+        }
+    }
+
+    public func fetchUpdates(completion: @escaping (Error?) -> Void) {
+        let query = CKQuery(recordType: "Expense", predicate: NSPredicate(value: true))
+        database.perform(query, inZoneWith: nil) { records, error in
+            if let error = error {
+                completion(error)
+                return
+            }
+            guard let records = records else {
+                completion(nil)
+                return
+            }
+            self.context.perform {
+                do {
+                    try self.merge(records: records)
+                    if self.context.hasChanges {
+                        try self.context.save()
+                    }
+                    completion(nil)
+                } catch {
+                    completion(error)
+                }
+            }
+        }
     }
 }
 #else
@@ -20,6 +128,9 @@ import Foundation
 public class CloudSyncManager {
     public init() {}
     public func sync(expenses: [Any], completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+    public func fetchUpdates(completion: @escaping (Error?) -> Void) {
         completion(nil)
     }
 }

--- a/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
+++ b/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
@@ -1,0 +1,65 @@
+#if canImport(CloudKit) && canImport(CoreData)
+import XCTest
+import CloudKit
+@testable import ExpenseStore
+
+final class CloudSyncManagerTests: XCTestCase {
+    class MockDatabase: CKDatabaseProtocol {
+        var savedRecords: [CKRecord] = []
+        var queryResults: [CKRecord] = []
+        func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void) {
+            savedRecords.append(record)
+            completionHandler(record, nil)
+        }
+        func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void) {
+            completionHandler(queryResults, nil)
+        }
+    }
+
+    func testSyncSavesRecords() throws {
+        let mockDB = MockDatabase()
+        let context = PersistenceController(inMemory: true).container.viewContext
+        let manager = CloudSyncManager(database: mockDB, context: context)
+
+        let expense = Expense(context: context)
+        expense.id = UUID()
+        expense.title = "Coffee"
+        expense.amount = 3.5
+        expense.date = Date()
+
+        let exp = expectation(description: "sync")
+        manager.sync(expenses: [expense]) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(mockDB.savedRecords.count, 1)
+        XCTAssertEqual(mockDB.savedRecords.first?["title"] as? String, "Coffee")
+    }
+
+    func testFetchUpdatesMergesRecords() throws {
+        let mockDB = MockDatabase()
+        let context = PersistenceController(inMemory: true).container.viewContext
+        let manager = CloudSyncManager(database: mockDB, context: context)
+
+        let recordID = CKRecord.ID(recordName: UUID().uuidString)
+        let record = CKRecord(recordType: "Expense", recordID: recordID)
+        record["title"] = "Tea" as CKRecordValue
+        record["amount"] = 2.0 as CKRecordValue
+        record["date"] = Date() as CKRecordValue
+        mockDB.queryResults = [record]
+
+        let exp = expectation(description: "fetch")
+        manager.fetchUpdates { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        let req: NSFetchRequest<Expense> = Expense.fetchRequest()
+        let results = try context.fetch(req)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.title, "Tea")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- create `CKDatabaseProtocol` and implement CloudKit syncing in `CloudSyncManager`
- merge fetched CloudKit records into Core Data
- add `CloudSyncManagerTests` with a mock database

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_683fc49c4b5483208da406a99b77838f