### PR TITLE
Add unit tests for budget/recurring expense creation and chart totals

### DIFF
--- a/Sources/DataVisualizer/DataVisualizer.swift
+++ b/Sources/DataVisualizer/DataVisualizer.swift
@@ -43,6 +43,25 @@ public struct ExpensesChartView: View {
         monthlyTotals.map(\.total).max() ?? 0
     }
 
+    /// Returns the total expense amounts grouped by month, in ascending order.
+    /// This helper is exposed for testing purposes.
+    public func monthlyTotalValuesForTesting() -> [Double] {
+        let request: NSFetchRequest<Expense> = Expense.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \Expense.date, ascending: true)]
+        do {
+            let results = try context.fetch(request)
+            let calendar = Calendar.current
+            let grouped = Dictionary(grouping: results) { expense -> Date in
+                calendar.date(from: calendar.dateComponents([.year, .month], from: expense.date)) ?? expense.date
+            }
+            return grouped
+                .sorted { $0.key < $1.key }
+                .map { (_, expenses) in expenses.reduce(0) { $0 + $1.amount } }
+        } catch {
+            return []
+        }
+    }
+
     private var monthFormatter: DateFormatter {
         let df = DateFormatter()
         df.dateFormat = "MMM"
@@ -71,5 +90,7 @@ import Foundation
 
 public struct ExpensesChartView {
     public init(context: Any? = nil) {}
+
+    public func monthlyTotalValuesForTesting() -> [Double] { [] }
 }
 #endif

--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -1,12 +1,39 @@
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(CoreData)
 import XCTest
 import SwiftUI
+import CoreData
+import ExpenseStore
 @testable import DataVisualizer
 
 final class ExpensesChartViewTests: XCTestCase {
     func testViewInitialization() {
         let view = ExpensesChartView()
         XCTAssertNotNil(view)
+    }
+
+    func testMonthlyTotalsSummarization() throws {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+
+        func makeExpense(amount: Double, date: Date) {
+            let expense = Expense(context: ctx)
+            expense.id = UUID()
+            expense.title = "tmp"
+            expense.amount = amount
+            expense.date = date
+        }
+
+        let cal = Calendar.current
+        makeExpense(amount: 10, date: cal.date(from: DateComponents(year: 2023, month: 1, day: 1))!)
+        makeExpense(amount: 20, date: cal.date(from: DateComponents(year: 2023, month: 1, day: 5))!)
+        makeExpense(amount: 5,  date: cal.date(from: DateComponents(year: 2023, month: 2, day: 3))!)
+        makeExpense(amount: 15, date: cal.date(from: DateComponents(year: 2023, month: 2, day: 10))!)
+
+        try ctx.save()
+
+        let view = ExpensesChartView(context: ctx)
+        let totals = view.monthlyTotalValuesForTesting()
+        XCTAssertEqual(totals, [30, 20])
     }
 }
 #endif

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -65,5 +65,38 @@ final class PersistenceControllerTests: XCTestCase {
         bFetch = try ctx.fetch(Budget.fetchRequest())
         XCTAssertEqual(bFetch.count, 0)
     }
+
+    func testAddRecurringExpenseCreatesObject() throws {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let start = Date()
+
+        let recurring = try controller.addRecurringExpense(title: "Internet", amount: 60, startDate: start, frequency: "Monthly")
+
+        let fetch: [RecurringExpense] = try ctx.fetch(RecurringExpense.fetchRequest())
+        XCTAssertEqual(fetch.count, 1)
+        if let first = fetch.first {
+            XCTAssertEqual(first.id, recurring.id)
+            XCTAssertEqual(first.title, "Internet")
+            XCTAssertEqual(first.amount, 60)
+            XCTAssertEqual(first.startDate, start)
+            XCTAssertEqual(first.frequency, "Monthly")
+        }
+    }
+
+    func testAddBudgetCreatesObject() throws {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+
+        let budget = try controller.addBudget(category: "Travel", limit: 500)
+
+        let fetch: [Budget] = try ctx.fetch(Budget.fetchRequest())
+        XCTAssertEqual(fetch.count, 1)
+        if let first = fetch.first {
+            XCTAssertEqual(first.id, budget.id)
+            XCTAssertEqual(first.category, "Travel")
+            XCTAssertEqual(first.limit, 500)
+        }
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- expose `ExpensesChartView` monthly totals for testing
- verify chart totals summarization on sample data
- ensure `addBudget` and `addRecurringExpense` create objects with expected values

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_683fc49e7878832097103be20cda2d41