### PR TITLE
Add budget and recurring expense management

### DIFF
--- a/ExpenseTracker/BudgetListView.swift
+++ b/ExpenseTracker/BudgetListView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import ExpenseStore
+
+struct BudgetListView: View {
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    @FetchRequest(
+        entity: Budget.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Budget.category, ascending: true)],
+        animation: .default
+    ) private var budgets: FetchedResults<Budget>
+
+    @State private var showEditor = false
+    @State private var editingBudget: Budget?
+
+    init(persistence: PersistenceController = .shared) {
+        self.persistence = persistence
+    }
+
+    var body: some View {
+        List {
+            ForEach(budgets, id: \.id) { budget in
+                VStack(alignment: .leading) {
+                    Text(budget.category)
+                    Text(budget.limit, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    editingBudget = budget
+                    showEditor = true
+                }
+            }
+            .onDelete(perform: removeBudget)
+        }
+        .navigationTitle("Budgets")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { editingBudget = nil; showEditor = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            BudgetEditView(budget: editingBudget, persistence: persistence)
+                .environment(\.managedObjectContext, context)
+        }
+    }
+
+    private func removeBudget(at offsets: IndexSet) {
+        for index in offsets {
+            let budget = budgets[index]
+            try? persistence.deleteBudget(budget)
+        }
+    }
+}
+
+struct BudgetEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    var budget: Budget?
+
+    @State private var category: String
+    @State private var limit: String
+
+    init(budget: Budget? = nil, persistence: PersistenceController = .shared) {
+        self.budget = budget
+        self.persistence = persistence
+        _category = State(initialValue: budget?.category ?? "")
+        _limit = State(initialValue: budget.map { String($0.limit) } ?? "")
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Category", text: $category)
+                TextField("Limit", text: $limit)
+                    .keyboardType(.decimalPad)
+            }
+            .navigationTitle(budget == nil ? "Add Budget" : "Edit Budget")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let amount = Double(limit) else { return }
+        do {
+            if let budget = budget {
+                budget.category = category
+                budget.limit = amount
+                try context.save()
+            } else {
+                _ = try persistence.addBudget(category: category, limit: amount)
+            }
+            dismiss()
+        } catch {
+            print("Save error: \(error)")
+        }
+    }
+}
+
+#Preview {
+    let controller = PersistenceController(inMemory: true)
+    let ctx = controller.container.viewContext
+    _ = try? controller.addBudget(category: "Food", limit: 200)
+    return NavigationView { BudgetListView(persistence: controller) }
+        .environment(\.managedObjectContext, ctx)
+}

--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -16,6 +16,12 @@ struct ContentView: View {
                 NavigationView { ExpenseListView() }
                     .environment(\.managedObjectContext, context)
                     .tabItem { Label("Expenses", systemImage: "list.bullet") }
+                NavigationView { BudgetListView() }
+                    .environment(\.managedObjectContext, context)
+                    .tabItem { Label("Budgets", systemImage: "dollarsign.circle") }
+                NavigationView { RecurringExpenseListView() }
+                    .environment(\.managedObjectContext, context)
+                    .tabItem { Label("Recurring", systemImage: "repeat") }
                 NavigationView { ReceiptCaptureView() }
                     .tabItem { Label("Scan", systemImage: "camera") }
             }

--- a/ExpenseTracker/RecurringExpenseListView.swift
+++ b/ExpenseTracker/RecurringExpenseListView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import ExpenseStore
+
+struct RecurringExpenseListView: View {
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    @FetchRequest(
+        entity: RecurringExpense.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \RecurringExpense.startDate, ascending: true)],
+        animation: .default
+    ) private var expenses: FetchedResults<RecurringExpense>
+
+    @State private var showEditor = false
+    @State private var editingExpense: RecurringExpense?
+
+    init(persistence: PersistenceController = .shared) {
+        self.persistence = persistence
+    }
+
+    var body: some View {
+        List {
+            ForEach(expenses, id: \.id) { expense in
+                VStack(alignment: .leading) {
+                    Text(expense.title)
+                    HStack {
+                        Text(expense.amount, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                        Spacer()
+                        Text(expense.frequency)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    editingExpense = expense
+                    showEditor = true
+                }
+            }
+            .onDelete(perform: removeExpense)
+        }
+        .navigationTitle("Recurring")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { editingExpense = nil; showEditor = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            RecurringExpenseEditView(expense: editingExpense, persistence: persistence)
+                .environment(\.managedObjectContext, context)
+        }
+    }
+
+    private func removeExpense(at offsets: IndexSet) {
+        for index in offsets {
+            let ex = expenses[index]
+            try? persistence.deleteRecurringExpense(ex)
+        }
+    }
+}
+
+struct RecurringExpenseEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    var expense: RecurringExpense?
+
+    @State private var title: String
+    @State private var amount: String
+    @State private var startDate: Date
+    @State private var frequency: RecurrenceFrequency
+
+    init(expense: RecurringExpense? = nil, persistence: PersistenceController = .shared) {
+        self.expense = expense
+        self.persistence = persistence
+        _title = State(initialValue: expense?.title ?? "")
+        _amount = State(initialValue: expense.map { String($0.amount) } ?? "")
+        _startDate = State(initialValue: expense?.startDate ?? Date())
+        _frequency = State(initialValue: RecurrenceFrequency(rawValue: expense?.frequency ?? "") ?? .monthly)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Title", text: $title)
+                TextField("Amount", text: $amount)
+                    .keyboardType(.decimalPad)
+                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+                Picker("Frequency", selection: $frequency) {
+                    ForEach(RecurrenceFrequency.allCases, id: \.self) { f in
+                        Text(f.rawValue.capitalized).tag(f)
+                    }
+                }
+            }
+            .navigationTitle(expense == nil ? "Add Recurring" : "Edit Recurring")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let amt = Double(amount) else { return }
+        do {
+            if let exp = expense {
+                exp.title = title
+                exp.amount = amt
+                exp.startDate = startDate
+                exp.frequency = frequency.rawValue
+                try context.save()
+            } else {
+                _ = try persistence.addRecurringExpense(title: title, amount: amt, startDate: startDate, frequency: frequency.rawValue)
+            }
+            dismiss()
+        } catch {
+            print("Save error: \(error)")
+        }
+    }
+}
+
+#Preview {
+    let controller = PersistenceController(inMemory: true)
+    let ctx = controller.container.viewContext
+    _ = try? controller.addRecurringExpense(title: "Gym", amount: 50, startDate: Date(), frequency: "Weekly")
+    return NavigationView { RecurringExpenseListView(persistence: controller) }
+        .environment(\.managedObjectContext, ctx)
+}

--- a/Sources/ExpenseTracker/UI/BudgetListView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetListView.swift
@@ -1,0 +1,120 @@
+#if canImport(SwiftUI) && canImport(CoreData)
+import SwiftUI
+import CoreData
+import ExpenseStore
+
+struct BudgetListView: View {
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    @FetchRequest(
+        entity: Budget.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Budget.category, ascending: true)],
+        animation: .default
+    ) private var budgets: FetchedResults<Budget>
+
+    @State private var showEditor = false
+    @State private var editingBudget: Budget?
+
+    init(persistence: PersistenceController = .shared) {
+        self.persistence = persistence
+    }
+
+    var body: some View {
+        List {
+            ForEach(budgets, id: \.id) { budget in
+                VStack(alignment: .leading) {
+                    Text(budget.category)
+                    Text(budget.limit, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    editingBudget = budget
+                    showEditor = true
+                }
+            }
+            .onDelete(perform: removeBudget)
+        }
+        .navigationTitle("Budgets")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { editingBudget = nil; showEditor = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            BudgetEditView(budget: editingBudget, persistence: persistence)
+                .environment(\.managedObjectContext, context)
+        }
+    }
+
+    private func removeBudget(at offsets: IndexSet) {
+        for index in offsets {
+            let budget = budgets[index]
+            try? persistence.deleteBudget(budget)
+        }
+    }
+}
+
+struct BudgetEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    var budget: Budget?
+
+    @State private var category: String
+    @State private var limit: String
+
+    init(budget: Budget? = nil, persistence: PersistenceController = .shared) {
+        self.budget = budget
+        self.persistence = persistence
+        _category = State(initialValue: budget?.category ?? "")
+        _limit = State(initialValue: budget.map { String($0.limit) } ?? "")
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Category", text: $category)
+                TextField("Limit", text: $limit)
+                    .keyboardType(.decimalPad)
+            }
+            .navigationTitle(budget == nil ? "Add Budget" : "Edit Budget")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let amount = Double(limit) else { return }
+        do {
+            if let budget = budget {
+                budget.category = category
+                budget.limit = amount
+                try context.save()
+            } else {
+                _ = try persistence.addBudget(category: category, limit: amount)
+            }
+            dismiss()
+        } catch {
+            print("Save error: \(error)")
+        }
+    }
+}
+
+#Preview {
+    let controller = PersistenceController(inMemory: true)
+    let ctx = controller.container.viewContext
+    _ = try? controller.addBudget(category: "Food", limit: 200)
+    return NavigationView { BudgetListView(persistence: controller) }
+        .environment(\.managedObjectContext, ctx)
+}
+#endif

--- a/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
+++ b/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
@@ -1,0 +1,136 @@
+#if canImport(SwiftUI) && canImport(CoreData)
+import SwiftUI
+import CoreData
+import ExpenseStore
+
+struct RecurringExpenseListView: View {
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    @FetchRequest(
+        entity: RecurringExpense.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \RecurringExpense.startDate, ascending: true)],
+        animation: .default
+    ) private var expenses: FetchedResults<RecurringExpense>
+
+    @State private var showEditor = false
+    @State private var editingExpense: RecurringExpense?
+
+    init(persistence: PersistenceController = .shared) {
+        self.persistence = persistence
+    }
+
+    var body: some View {
+        List {
+            ForEach(expenses, id: \.id) { expense in
+                VStack(alignment: .leading) {
+                    Text(expense.title)
+                    HStack {
+                        Text(expense.amount, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                        Spacer()
+                        Text(expense.frequency)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    editingExpense = expense
+                    showEditor = true
+                }
+            }
+            .onDelete(perform: removeExpense)
+        }
+        .navigationTitle("Recurring")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { editingExpense = nil; showEditor = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showEditor) {
+            RecurringExpenseEditView(expense: editingExpense, persistence: persistence)
+                .environment(\.managedObjectContext, context)
+        }
+    }
+
+    private func removeExpense(at offsets: IndexSet) {
+        for index in offsets {
+            let ex = expenses[index]
+            try? persistence.deleteRecurringExpense(ex)
+        }
+    }
+}
+
+struct RecurringExpenseEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.managedObjectContext) private var context
+    private let persistence: PersistenceController
+    var expense: RecurringExpense?
+
+    @State private var title: String
+    @State private var amount: String
+    @State private var startDate: Date
+    @State private var frequency: RecurrenceFrequency
+
+    init(expense: RecurringExpense? = nil, persistence: PersistenceController = .shared) {
+        self.expense = expense
+        self.persistence = persistence
+        _title = State(initialValue: expense?.title ?? "")
+        _amount = State(initialValue: expense.map { String($0.amount) } ?? "")
+        _startDate = State(initialValue: expense?.startDate ?? Date())
+        _frequency = State(initialValue: RecurrenceFrequency(rawValue: expense?.frequency ?? "") ?? .monthly)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Title", text: $title)
+                TextField("Amount", text: $amount)
+                    .keyboardType(.decimalPad)
+                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+                Picker("Frequency", selection: $frequency) {
+                    ForEach(RecurrenceFrequency.allCases, id: \.self) { f in
+                        Text(f.rawValue.capitalized).tag(f)
+                    }
+                }
+            }
+            .navigationTitle(expense == nil ? "Add Recurring" : "Edit Recurring")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let amt = Double(amount) else { return }
+        do {
+            if let exp = expense {
+                exp.title = title
+                exp.amount = amt
+                exp.startDate = startDate
+                exp.frequency = frequency.rawValue
+                try context.save()
+            } else {
+                _ = try persistence.addRecurringExpense(title: title, amount: amt, startDate: startDate, frequency: frequency.rawValue)
+            }
+            dismiss()
+        } catch {
+            print("Save error: \(error)")
+        }
+    }
+}
+
+#Preview {
+    let controller = PersistenceController(inMemory: true)
+    let ctx = controller.container.viewContext
+    _ = try? controller.addRecurringExpense(title: "Gym", amount: 50, startDate: Date(), frequency: "Weekly")
+    return NavigationView { RecurringExpenseListView(persistence: controller) }
+        .environment(\.managedObjectContext, ctx)
+}
+#endif

--- a/Tests/ExpenseTrackerTests/BudgetRecurringViewTests.swift
+++ b/Tests/ExpenseTrackerTests/BudgetRecurringViewTests.swift
@@ -1,0 +1,22 @@
+#if canImport(SwiftUI) && canImport(CoreData)
+import XCTest
+import SwiftUI
+@testable import ExpenseTracker
+import ExpenseStore
+
+final class BudgetRecurringViewTests: XCTestCase {
+    func testBudgetListViewInit() {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let view = BudgetListView(persistence: controller).environment(\.managedObjectContext, ctx)
+        XCTAssertNotNil(view)
+    }
+
+    func testRecurringExpenseListViewInit() {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let view = RecurringExpenseListView(persistence: controller).environment(\.managedObjectContext, ctx)
+        XCTAssertNotNil(view)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- implement BudgetListView and RecurringExpenseListView with editing helpers
- expose these views to the app and to the Swift package
- wire budget and recurring tabs into ContentView
- add basic view initialization tests

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_683fc49d4e04832088ff419ecc0e34d3