### PR TITLE
Implement budget progress view and recurring scheduler

### DIFF
--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -24,6 +24,7 @@ public class RecurringExpense: NSManagedObject {
     @NSManaged public var title: String
     @NSManaged public var amount: Double
     @NSManaged public var startDate: Date
+    @NSManaged public var nextDate: Date
     @NSManaged public var frequency: String
 }
 
@@ -154,6 +155,12 @@ public struct PersistenceController {
         rstartDate.isOptional = false
         recurringProps.append(rstartDate)
 
+        let rnextDate = NSAttributeDescription()
+        rnextDate.name = "nextDate"
+        rnextDate.attributeType = .dateAttributeType
+        rnextDate.isOptional = false
+        recurringProps.append(rnextDate)
+
         let rfrequency = NSAttributeDescription()
         rfrequency.name = "frequency"
         rfrequency.attributeType = .stringAttributeType
@@ -199,6 +206,7 @@ public struct PersistenceController {
         obj.title = title
         obj.amount = amount
         obj.startDate = startDate
+        obj.nextDate = startDate
         obj.frequency = frequency
         try container.viewContext.save()
         return obj

--- a/Sources/ExpenseStore/RecurringExpenseScheduler.swift
+++ b/Sources/ExpenseStore/RecurringExpenseScheduler.swift
@@ -1,0 +1,46 @@
+#if canImport(CoreData)
+import Foundation
+import CoreData
+
+public class RecurringExpenseScheduler {
+    private let context: NSManagedObjectContext
+    private let calendar = Calendar.current
+
+    public init(context: NSManagedObjectContext = PersistenceController.shared.container.viewContext) {
+        self.context = context
+    }
+
+    private func advanceDate(_ date: Date, frequency: RecurrenceFrequency) -> Date {
+        switch frequency {
+        case .daily:
+            return calendar.date(byAdding: .day, value: 1, to: date) ?? date
+        case .weekly:
+            return calendar.date(byAdding: .weekOfYear, value: 1, to: date) ?? date
+        case .monthly:
+            return calendar.date(byAdding: .month, value: 1, to: date) ?? date
+        case .yearly:
+            return calendar.date(byAdding: .year, value: 1, to: date) ?? date
+        }
+    }
+
+    /// Checks for due recurring expenses and creates `Expense` records.
+    public func processDueExpenses(asOf date: Date = Date()) throws {
+        let request: NSFetchRequest<RecurringExpense> = RecurringExpense.fetchRequest()
+        request.predicate = NSPredicate(format: "nextDate <= %@", date as NSDate)
+        let items = try context.fetch(request)
+        for item in items {
+            let expense = Expense(context: context)
+            expense.id = UUID()
+            expense.title = item.title
+            expense.amount = item.amount
+            expense.date = item.nextDate
+            if let freq = RecurrenceFrequency(rawValue: item.frequency) {
+                item.nextDate = advanceDate(item.nextDate, frequency: freq)
+            }
+        }
+        if context.hasChanges {
+            try context.save()
+        }
+    }
+}
+#endif

--- a/Sources/ExpenseTracker/UI/BudgetProgressView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetProgressView.swift
@@ -1,0 +1,41 @@
+#if canImport(SwiftUI) && canImport(CoreData)
+import SwiftUI
+import CoreData
+import ExpenseStore
+
+struct BudgetProgressView: View {
+    @Environment(\.managedObjectContext) private var context
+    @FetchRequest(
+        entity: Budget.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Budget.category, ascending: true)],
+        animation: .default
+    ) private var budgets: FetchedResults<Budget>
+
+    var body: some View {
+        List {
+            ForEach(budgets, id: \.id) { budget in
+                VStack(alignment: .leading) {
+                    Text(budget.category)
+                    let spent = spending(for: budget)
+                    ProgressView(value: spent, total: budget.limit)
+                    let code = Locale.current.currency?.identifier ?? "USD"
+                    Text("\(spent, format: .currency(code: code)) of \(budget.limit, format: .currency(code: code))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Budgets")
+    }
+
+    private func spending(for budget: Budget) -> Double {
+        let req: NSFetchRequest<Expense> = Expense.fetchRequest()
+        let cal = Calendar.current
+        let startOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: Date())) ?? Date()
+        let nextMonth = cal.date(byAdding: .month, value: 1, to: startOfMonth) ?? Date()
+        req.predicate = NSPredicate(format: "category == %@ AND date >= %@ AND date < %@", budget.category, startOfMonth as NSDate, nextMonth as NSDate)
+        let expenses = (try? context.fetch(req)) ?? []
+        return expenses.reduce(0) { $0 + $1.amount }
+    }
+}
+#endif

--- a/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
+++ b/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
@@ -114,6 +114,7 @@ struct RecurringExpenseEditView: View {
                 exp.title = title
                 exp.amount = amt
                 exp.startDate = startDate
+                exp.nextDate = startDate
                 exp.frequency = frequency.rawValue
                 try context.save()
             } else {

--- a/Sources/UserAuth/UserManager.swift
+++ b/Sources/UserAuth/UserManager.swift
@@ -7,11 +7,19 @@ import AuthenticationServices
 
 public class UserManager: NSObject, ObservableObject {
     @Published public private(set) var currentUser: User?
+    private static let userKey = "CurrentUser"
 
-    public override init() {}
+    public override init() {
+        super.init()
+        if let data = UserDefaults.standard.data(forKey: Self.userKey),
+           let user = try? JSONDecoder().decode(User.self, from: data) {
+            currentUser = user
+        }
+    }
 
     public func signInLocally(name: String) {
         currentUser = User(name: name)
+        persistCurrentUser()
     }
 
 #if canImport(AuthenticationServices)
@@ -26,6 +34,15 @@ public class UserManager: NSObject, ObservableObject {
 
     public func signOut() {
         currentUser = nil
+        persistCurrentUser()
+    }
+
+    private func persistCurrentUser() {
+        if let user = currentUser, let data = try? JSONEncoder().encode(user) {
+            UserDefaults.standard.set(data, forKey: Self.userKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.userKey)
+        }
     }
 }
 
@@ -37,6 +54,7 @@ extension UserManager: ASAuthorizationControllerDelegate {
                 .compactMap { $0 }
                 .joined(separator: " ")
             currentUser = User(id: credential.user, name: fullName)
+            persistCurrentUser()
         }
     }
 
@@ -51,15 +69,32 @@ import Foundation
 
 public class UserManager: NSObject {
     public private(set) var currentUser: User?
+    private static let userKey = "CurrentUser"
 
-    public override init() {}
+    public override init() {
+        super.init()
+        if let data = UserDefaults.standard.data(forKey: Self.userKey),
+           let user = try? JSONDecoder().decode(User.self, from: data) {
+            currentUser = user
+        }
+    }
 
     public func signInLocally(name: String) {
         currentUser = User(name: name)
+        persistCurrentUser()
     }
 
     public func signOut() {
         currentUser = nil
+        persistCurrentUser()
+    }
+
+    private func persistCurrentUser() {
+        if let user = currentUser, let data = try? JSONEncoder().encode(user) {
+            UserDefaults.standard.set(data, forKey: Self.userKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.userKey)
+        }
     }
 }
 #endif

--- a/Tests/ExpenseTrackerTests/BudgetProgressViewTests.swift
+++ b/Tests/ExpenseTrackerTests/BudgetProgressViewTests.swift
@@ -1,0 +1,15 @@
+#if canImport(SwiftUI) && canImport(CoreData)
+import XCTest
+import SwiftUI
+@testable import ExpenseTracker
+import ExpenseStore
+
+final class BudgetProgressViewTests: XCTestCase {
+    func testViewInitialization() {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let view = BudgetProgressView().environment(\.managedObjectContext, ctx)
+        XCTAssertNotNil(view)
+    }
+}
+#endif

--- a/Tests/ExpenseTrackerTests/RecurringExpenseSchedulerTests.swift
+++ b/Tests/ExpenseTrackerTests/RecurringExpenseSchedulerTests.swift
@@ -1,0 +1,23 @@
+#if canImport(CoreData)
+import XCTest
+@testable import ExpenseStore
+
+final class RecurringExpenseSchedulerTests: XCTestCase {
+    func testSchedulerCreatesExpenseAndAdvancesDate() throws {
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let initial = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let recurring = try controller.addRecurringExpense(title: "Gym", amount: 50, startDate: initial, frequency: "daily")
+        recurring.nextDate = initial
+        try ctx.save()
+
+        let scheduler = RecurringExpenseScheduler(context: ctx)
+        try scheduler.processDueExpenses(asOf: Date())
+
+        let expReq: NSFetchRequest<Expense> = Expense.fetchRequest()
+        let expenses = try ctx.fetch(expReq)
+        XCTAssertEqual(expenses.count, 1)
+        XCTAssertGreaterThan(recurring.nextDate, initial)
+    }
+}
+#endif

--- a/Tests/ExpenseTrackerTests/UserManagerTests.swift
+++ b/Tests/ExpenseTrackerTests/UserManagerTests.swift
@@ -6,5 +6,9 @@ final class UserManagerTests: XCTestCase {
         let manager = UserManager()
         manager.signInLocally(name: "Alice")
         XCTAssertEqual(manager.currentUser?.name, "Alice")
+
+        let reloaded = UserManager()
+        XCTAssertEqual(reloaded.currentUser?.name, "Alice")
+        reloaded.signOut()
     }
 }


### PR DESCRIPTION
## Summary
- show budgets with current month's spending in a new `BudgetProgressView`
- track `nextDate` for recurring expenses and add `RecurringExpenseScheduler`
- store signed-in `User` in `UserDefaults` via `UserManager`
- adjust recurring expense editing to keep `nextDate`
- test new scheduler, view and persistence functionality

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684040aa92448320983ee664842aa9b5