### PR TITLE
Process recurring expenses at startup

### DIFF
--- a/ExpenseTracker/ExpenseTrackerApp.swift
+++ b/ExpenseTracker/ExpenseTrackerApp.swift
@@ -4,6 +4,17 @@ import ExpenseStore
 @main
 struct ExpenseTrackerApp: App {
     let persistenceController = PersistenceController.shared
+    let scheduler: RecurringExpenseScheduler
+
+    init() {
+        scheduler = RecurringExpenseScheduler(context: persistenceController.container.viewContext)
+        do {
+            try scheduler.processDueExpenses()
+        } catch {
+            print("Failed to process recurring expenses: \(error)")
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- initialize `RecurringExpenseScheduler` in `ExpenseTrackerApp`
- call `processDueExpenses()` when the app launches

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_68404565d8ec832086080d804865bbe2