### PR TITLE
Update chart view context handling

### DIFF
--- a/ExpenseTracker/ContentView.swift
+++ b/ExpenseTracker/ContentView.swift
@@ -11,7 +11,8 @@ struct ContentView: View {
     var body: some View {
         if userManager.currentUser != nil {
             TabView {
-                NavigationView { ExpensesChartView(context: context) }
+                NavigationView { ExpensesChartView() }
+                    .environment(\.managedObjectContext, context)
                     .tabItem { Label("Charts", systemImage: "chart.bar") }
                 NavigationView { ExpenseListView() }
                     .environment(\.managedObjectContext, context)

--- a/Sources/DataVisualizer/DataVisualizer.swift
+++ b/Sources/DataVisualizer/DataVisualizer.swift
@@ -4,22 +4,14 @@ import CoreData
 import ExpenseStore
 
 public struct ExpensesChartView: View {
+    @Environment(\.managedObjectContext) private var context
     @FetchRequest private var expenses: FetchedResults<Expense>
-    private let context: NSManagedObjectContext
 
-    public init(context: NSManagedObjectContext? = nil) {
-        if let ctx = context {
-            self.context = ctx
-        } else {
-            self.context = PersistenceController(inMemory: true).container.viewContext
-        }
-        _expenses = FetchRequest(
-            entity: Expense.entity(),
-            sortDescriptors: [NSSortDescriptor(keyPath: \Expense.date, ascending: true)],
-            animation: .default,
-            predicate: nil,
-            managedObjectContext: self.context
-        )
+    public init() {
+        var request: NSFetchRequest<Expense> = Expense.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \Expense.date, ascending: true)]
+        request.predicate = nil
+        _expenses = FetchRequest(fetchRequest: request, animation: .default)
     }
 
     struct MonthTotal: Identifiable {
@@ -45,7 +37,7 @@ public struct ExpensesChartView: View {
 
     /// Returns the total expense amounts grouped by month, in ascending order.
     /// This helper is exposed for testing purposes.
-    public func monthlyTotalValuesForTesting() -> [Double] {
+    public func monthlyTotalValuesForTesting(in context: NSManagedObjectContext) -> [Double] {
         let request: NSFetchRequest<Expense> = Expense.fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Expense.date, ascending: true)]
         do {
@@ -89,8 +81,8 @@ public struct ExpensesChartView: View {
 import Foundation
 
 public struct ExpensesChartView {
-    public init(context: Any? = nil) {}
+    public init() {}
 
-    public func monthlyTotalValuesForTesting() -> [Double] { [] }
+    public func monthlyTotalValuesForTesting(in context: Any? = nil) -> [Double] { [] }
 }
 #endif

--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -8,9 +8,9 @@ final class ExpenseTrackerTests: XCTestCase {
     func testChartViewInitialization() throws {
         #if canImport(CoreData)
         let context = PersistenceController(inMemory: true).container.viewContext
-        _ = ExpensesChartView(context: context)
+        _ = ExpensesChartView().environment(\.managedObjectContext, context)
         #else
-        _ = ExpensesChartView(context: nil)
+        _ = ExpensesChartView()
         #endif
         XCTAssertTrue(true)
     }

--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -7,7 +7,9 @@ import ExpenseStore
 
 final class ExpensesChartViewTests: XCTestCase {
     func testViewInitialization() {
-        let view = ExpensesChartView()
+        let controller = PersistenceController(inMemory: true)
+        let ctx = controller.container.viewContext
+        let view = ExpensesChartView().environment(\.managedObjectContext, ctx)
         XCTAssertNotNil(view)
     }
 
@@ -31,8 +33,7 @@ final class ExpensesChartViewTests: XCTestCase {
 
         try ctx.save()
 
-        let view = ExpensesChartView(context: ctx)
-        let totals = view.monthlyTotalValuesForTesting()
+        let totals = ExpensesChartView().monthlyTotalValuesForTesting(in: ctx)
         XCTAssertEqual(totals, [30, 20])
     }
 }


### PR DESCRIPTION
## Summary
- use environment to supply the context for `ExpensesChartView`
- build the fetch request with a typed `NSFetchRequest`
- update `ContentView` to inject context through `.environment`
- adjust tests for new initializer and helper

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6840f0e258608320a607c45b084afa3f