### PR TITLE
Update tests to pass context via environment

### DIFF
--- a/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpenseTrackerTests.swift
@@ -9,6 +9,7 @@ final class ExpenseTrackerTests: XCTestCase {
         #if canImport(CoreData)
         let context = PersistenceController(inMemory: true).container.viewContext
         _ = ExpensesChartView(context: context)
+            .environment(\.managedObjectContext, context)
         #else
         _ = ExpensesChartView(context: nil)
         #endif

--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -32,6 +32,7 @@ final class ExpensesChartViewTests: XCTestCase {
         try ctx.save()
 
         let view = ExpensesChartView(context: ctx)
+            .environment(\.managedObjectContext, ctx)
         let totals = view.monthlyTotalValuesForTesting()
         XCTAssertEqual(totals, [30, 20])
     }


### PR DESCRIPTION
## Summary
- attach the managed object context using the environment modifier when creating `ExpensesChartView` in tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6840f0e396408320b5662368d19355e8