### PR TITLE
Add Sendable to CKDatabaseProtocol closures

### DIFF
--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -3,8 +3,15 @@ import CloudKit
 import CoreData
 
 public protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
+    func save(
+        _ record: CKRecord,
+        completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void
+    )
+    func perform(
+        _ query: CKQuery,
+        inZoneWith zoneID: CKRecordZone.ID?,
+        completionHandler: @Sendable @escaping ([CKRecord]?, Error?) -> Void
+    )
 }
 
 extension CKDatabase: CKDatabaseProtocol {}

--- a/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
+++ b/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
@@ -7,11 +7,18 @@ final class CloudSyncManagerTests: XCTestCase {
     class MockDatabase: CKDatabaseProtocol {
         var savedRecords: [CKRecord] = []
         var queryResults: [CKRecord] = []
-        func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void) {
+        func save(
+            _ record: CKRecord,
+            completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void
+        ) {
             savedRecords.append(record)
             completionHandler(record, nil)
         }
-        func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void) {
+        func perform(
+            _ query: CKQuery,
+            inZoneWith zoneID: CKRecordZone.ID?,
+            completionHandler: @Sendable @escaping ([CKRecord]?, Error?) -> Void
+        ) {
             completionHandler(queryResults, nil)
         }
     }


### PR DESCRIPTION
## Summary
- update `CKDatabaseProtocol` to mark completion handlers as `@Sendable`
- adjust test `MockDatabase` to conform to new protocol

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6840f698f09883209fdd96c9ced35023