### PR TITLE
Switch to SwiftData persistence

### DIFF
--- a/Sources/ExpenseTracker/UI/BudgetListView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetListView.swift
@@ -1,16 +1,12 @@
-#if canImport(SwiftUI) && canImport(CoreData)
+#if canImport(SwiftUI) && canImport(SwiftData)
 import SwiftUI
-import CoreData
+import SwiftData
 import ExpenseStore
 
 struct BudgetListView: View {
-    @Environment(\.managedObjectContext) private var context
+    @Environment(\.modelContext) private var context
     private let persistence: PersistenceController
-    @FetchRequest(
-        entity: Budget.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \Budget.category, ascending: true)],
-        animation: .default
-    ) private var budgets: FetchedResults<Budget>
+    @Query(sort: [SortDescriptor(\.category)]) private var budgets: [Budget]
 
     @State private var showEditor = false
     @State private var editingBudget: Budget?
@@ -46,7 +42,7 @@ struct BudgetListView: View {
         }
         .sheet(isPresented: $showEditor) {
             BudgetEditView(budget: editingBudget, persistence: persistence)
-                .environment(\.managedObjectContext, context)
+                .environment(\.modelContext, context)
         }
     }
 
@@ -60,7 +56,7 @@ struct BudgetListView: View {
 
 struct BudgetEditView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.managedObjectContext) private var context
+    @Environment(\.modelContext) private var context
     private let persistence: PersistenceController
     var budget: Budget?
 
@@ -112,9 +108,9 @@ struct BudgetEditView: View {
 
 #Preview {
     let controller = PersistenceController(inMemory: true)
-    let ctx = controller.container.viewContext
+    let ctx = controller.container.mainContext
     _ = try? controller.addBudget(category: "Food", limit: 200)
     return NavigationView { BudgetListView(persistence: controller) }
-        .environment(\.managedObjectContext, ctx)
+        .environment(\.modelContext, ctx)
 }
 #endif

--- a/Sources/ExpenseTracker/UI/BudgetProgressView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetProgressView.swift
@@ -1,15 +1,11 @@
-#if canImport(SwiftUI) && canImport(CoreData)
+#if canImport(SwiftUI) && canImport(SwiftData)
 import SwiftUI
-import CoreData
+import SwiftData
 import ExpenseStore
 
 struct BudgetProgressView: View {
-    @Environment(\.managedObjectContext) private var context
-    @FetchRequest(
-        entity: Budget.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \Budget.category, ascending: true)],
-        animation: .default
-    ) private var budgets: FetchedResults<Budget>
+    @Environment(\.modelContext) private var context
+    @Query(sort: [SortDescriptor(\.category)]) private var budgets: [Budget]
 
     var body: some View {
         List {
@@ -29,12 +25,12 @@ struct BudgetProgressView: View {
     }
 
     private func spending(for budget: Budget) -> Double {
-        let req: NSFetchRequest<Expense> = Expense.fetchRequest()
+        let descriptor = FetchDescriptor<Expense>(predicate: #Predicate { $0.category == budget.category && $0.date >= startOfMonth && $0.date < nextMonth })
         let cal = Calendar.current
         let startOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: Date())) ?? Date()
         let nextMonth = cal.date(byAdding: .month, value: 1, to: startOfMonth) ?? Date()
         req.predicate = NSPredicate(format: "category == %@ AND date >= %@ AND date < %@", budget.category, startOfMonth as NSDate, nextMonth as NSDate)
-        let expenses = (try? context.fetch(req)) ?? []
+        let expenses = (try? context.fetch(descriptor)) ?? []
         return expenses.reduce(0) { $0 + $1.amount }
     }
 }

--- a/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
+++ b/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
@@ -1,16 +1,12 @@
-#if canImport(SwiftUI) && canImport(CoreData)
+#if canImport(SwiftUI) && canImport(SwiftData)
 import SwiftUI
-import CoreData
+import SwiftData
 import ExpenseStore
 
 struct RecurringExpenseListView: View {
-    @Environment(\.managedObjectContext) private var context
+    @Environment(\.modelContext) private var context
     private let persistence: PersistenceController
-    @FetchRequest(
-        entity: RecurringExpense.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \RecurringExpense.startDate, ascending: true)],
-        animation: .default
-    ) private var expenses: FetchedResults<RecurringExpense>
+    @Query(sort: [SortDescriptor(\.startDate)]) private var expenses: [RecurringExpense]
 
     @State private var showEditor = false
     @State private var editingExpense: RecurringExpense?
@@ -50,7 +46,7 @@ struct RecurringExpenseListView: View {
         }
         .sheet(isPresented: $showEditor) {
             RecurringExpenseEditView(expense: editingExpense, persistence: persistence)
-                .environment(\.managedObjectContext, context)
+                .environment(\.modelContext, context)
         }
     }
 
@@ -64,7 +60,7 @@ struct RecurringExpenseListView: View {
 
 struct RecurringExpenseEditView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.managedObjectContext) private var context
+    @Environment(\.modelContext) private var context
     private let persistence: PersistenceController
     var expense: RecurringExpense?
 
@@ -129,9 +125,9 @@ struct RecurringExpenseEditView: View {
 
 #Preview {
     let controller = PersistenceController(inMemory: true)
-    let ctx = controller.container.viewContext
+    let ctx = controller.container.mainContext
     _ = try? controller.addRecurringExpense(title: "Gym", amount: 50, startDate: Date(), frequency: "Weekly")
     return NavigationView { RecurringExpenseListView(persistence: controller) }
-        .environment(\.managedObjectContext, ctx)
+        .environment(\.modelContext, ctx)
 }
 #endif

--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -1,28 +1,25 @@
-#if canImport(SwiftUI) && canImport(CoreData)
+#if canImport(SwiftUI) && canImport(SwiftData)
 import XCTest
 import SwiftUI
-import CoreData
+import SwiftData
 import ExpenseStore
 @testable import DataVisualizer
 
 final class ExpensesChartViewTests: XCTestCase {
     func testViewInitialization() {
         let controller = PersistenceController(inMemory: true)
-        let ctx = controller.container.viewContext
-        let view = ExpensesChartView().environment(\.managedObjectContext, ctx)
+        let ctx = controller.container.mainContext
+        let view = ExpensesChartView().environment(\.modelContext, ctx)
         XCTAssertNotNil(view)
     }
 
     func testMonthlyTotalsSummarization() throws {
         let controller = PersistenceController(inMemory: true)
-        let ctx = controller.container.viewContext
+        let ctx = controller.container.mainContext
 
         func makeExpense(amount: Double, date: Date) {
-            let expense = Expense(context: ctx)
-            expense.id = UUID()
-            expense.title = "tmp"
-            expense.amount = amount
-            expense.date = date
+            let expense = Expense(title: "tmp", amount: amount, date: date)
+            ctx.insert(expense)
         }
 
         let cal = Calendar.current
@@ -33,13 +30,7 @@ final class ExpensesChartViewTests: XCTestCase {
 
         try ctx.save()
 
-<<<<<<< codex/update-test-setup-for-expenseschartview
-        let view = ExpensesChartView(context: ctx)
-            .environment(\.managedObjectContext, ctx)
-        let totals = view.monthlyTotalValuesForTesting()
-=======
         let totals = ExpensesChartView().monthlyTotalValuesForTesting(in: ctx)
->>>>>>> main
         XCTAssertEqual(totals, [30, 20])
     }
 }


### PR DESCRIPTION
## Summary
- migrate Core Data models to SwiftData `@Model`
- swap Core Data stack for `ModelContainer`
- adjust CRUD helpers to use `ModelContext`
- update CloudKit sync for SwiftData
- adapt Budget and RecurringExpense SwiftUI views
- refactor chart view tests for SwiftData

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68432b160500832083aa66379fc9f62a