### PR TITLE
Update deployment target to iOS 17

### DIFF
--- a/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@ buildSettings = {
         PRODUCT_NAME = "$(TARGET_NAME)";
         CODE_SIGN_ENTITLEMENTS = ExpenseTracker/ExpenseTracker.entitlements;
         SWIFT_VERSION = 5.0;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
         TARGETED_DEVICE_FAMILY = "1,2";
     };
 name = Debug;
@@ -144,6 +145,7 @@ buildSettings = {
         PRODUCT_NAME = "$(TARGET_NAME)";
         CODE_SIGN_ENTITLEMENTS = ExpenseTracker/ExpenseTracker.entitlements;
         SWIFT_VERSION = 5.0;
+        IPHONEOS_DEPLOYMENT_TARGET = 17.0;
         TARGETED_DEVICE_FAMILY = "1,2";
     };
 name = Release;

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ExpenseTracker",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v17)
     ],
     products: [
         .library(name: "ReceiptScanner", targets: ["ReceiptScanner"]),


### PR DESCRIPTION
## Summary
- set `Package.swift` platform to iOS 17
- configure the Xcode project for iOS 17 deployment

## Testing
- `swift test --parallel` *(fails: source control conflict marker in ExpensesChartViewTests.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68432b188e408320938bfa27f7bcfed5