### PR TITLE
Switch tests to SwiftData in-memory container

### DIFF
--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -33,13 +33,7 @@ final class ExpensesChartViewTests: XCTestCase {
 
         try ctx.save()
 
-<<<<<<< codex/update-test-setup-for-expenseschartview
-        let view = ExpensesChartView(context: ctx)
-            .environment(\.managedObjectContext, ctx)
-        let totals = view.monthlyTotalValuesForTesting()
-=======
         let totals = ExpensesChartView().monthlyTotalValuesForTesting(in: ctx)
->>>>>>> main
         XCTAssertEqual(totals, [30, 20])
     }
 }

--- a/Tests/ExpenseTrackerTests/SwiftDataModels.swift
+++ b/Tests/ExpenseTrackerTests/SwiftDataModels.swift
@@ -1,0 +1,61 @@
+#if canImport(SwiftData)
+import SwiftData
+import ExpenseStore
+
+@Model public class ExpenseModel {
+    public var id: UUID
+    public var title: String
+    public var amount: Double
+    public var date: Date
+    public var category: String?
+    public var tags: [String]?
+    public var notes: String?
+    public var frequencyRaw: String?
+
+    public var frequency: RecurrenceFrequency? {
+        get { frequencyRaw.flatMap { RecurrenceFrequency(rawValue: $0) } }
+        set { frequencyRaw = newValue?.rawValue }
+    }
+
+    public init(id: UUID = UUID(), title: String, amount: Double, date: Date, category: String? = nil, tags: [String]? = nil, notes: String? = nil, frequency: RecurrenceFrequency? = nil) {
+        self.id = id
+        self.title = title
+        self.amount = amount
+        self.date = date
+        self.category = category
+        self.tags = tags
+        self.notes = notes
+        self.frequencyRaw = frequency?.rawValue
+    }
+}
+
+@Model public class RecurringExpenseModel {
+    public var id: UUID
+    public var title: String
+    public var amount: Double
+    public var startDate: Date
+    public var nextDate: Date
+    public var frequency: String
+
+    public init(id: UUID = UUID(), title: String, amount: Double, startDate: Date, nextDate: Date? = nil, frequency: String) {
+        self.id = id
+        self.title = title
+        self.amount = amount
+        self.startDate = startDate
+        self.nextDate = nextDate ?? startDate
+        self.frequency = frequency
+    }
+}
+
+@Model public class BudgetModel {
+    public var id: UUID
+    public var category: String
+    public var limit: Double
+
+    public init(id: UUID = UUID(), category: String, limit: Double) {
+        self.id = id
+        self.category = category
+        self.limit = limit
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- use SwiftData model container for in-memory tests
- remove leftover merge markers
- add simple SwiftData models for tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68432b1a55508320a3882e549288607c