### PR TITLE
Update deployment targets and annotate SwiftData APIs

### DIFF
--- a/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@ buildSettings = {
         CODE_SIGN_ENTITLEMENTS = ExpenseTracker/ExpenseTracker.entitlements;
         SWIFT_VERSION = 5.0;
         IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        MACOSX_DEPLOYMENT_TARGET = 14.0;
         TARGETED_DEVICE_FAMILY = "1,2";
     };
 name = Debug;
@@ -146,6 +147,7 @@ buildSettings = {
         CODE_SIGN_ENTITLEMENTS = ExpenseTracker/ExpenseTracker.entitlements;
         SWIFT_VERSION = 5.0;
         IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+        MACOSX_DEPLOYMENT_TARGET = 14.0;
         TARGETED_DEVICE_FAMILY = "1,2";
     };
 name = Release;

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "ExpenseTracker",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17),
+        .macOS(.v14)
     ],
     products: [
         .library(name: "ReceiptScanner", targets: ["ReceiptScanner"]),

--- a/Sources/DataVisualizer/DataVisualizer.swift
+++ b/Sources/DataVisualizer/DataVisualizer.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import SwiftData
 import ExpenseStore
 
+@available(iOS 17.0, macOS 14.0, *)
 public struct ExpensesChartView: View {
     @Environment(\.modelContext) private var context
 

--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -16,6 +16,7 @@ public protocol CKDatabaseProtocol {
 
 extension CKDatabase: CKDatabaseProtocol {}
 
+@available(iOS 17.0, macOS 14.0, *)
 public class CloudSyncManager {
     private let database: CKDatabaseProtocol
     private let context: ModelContext

--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -4,6 +4,7 @@ import SwiftData
 import CloudKit
 #endif
 
+@available(iOS 17.0, macOS 14.0, *)
 @Model
 public final class Expense {
     @Attribute(.unique) public var id: UUID
@@ -29,6 +30,7 @@ public final class Expense {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, *)
 @Model
 public final class RecurringExpense {
     @Attribute(.unique) public var id: UUID
@@ -49,6 +51,7 @@ public final class RecurringExpense {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, *)
 @Model
 public final class Budget {
     @Attribute(.unique) public var id: UUID
@@ -62,6 +65,7 @@ public final class Budget {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, *)
 public struct PersistenceController {
     public static let shared = PersistenceController()
     public let container: ModelContainer

--- a/Sources/ExpenseStore/RecurringExpenseScheduler.swift
+++ b/Sources/ExpenseStore/RecurringExpenseScheduler.swift
@@ -2,6 +2,7 @@
 import Foundation
 import SwiftData
 
+@available(iOS 17.0, macOS 14.0, *)
 public class RecurringExpenseScheduler {
     private let context: ModelContext
     private let calendar = Calendar.current

--- a/Sources/ExpenseTracker/UI/BudgetListView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import SwiftData
 import ExpenseStore
 
+@available(iOS 17.0, macOS 14.0, *)
 struct BudgetListView: View {
     @Environment(\.modelContext) private var context
     

--- a/Sources/ExpenseTracker/UI/BudgetProgressView.swift
+++ b/Sources/ExpenseTracker/UI/BudgetProgressView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import SwiftData
 import ExpenseStore
 
+@available(iOS 17.0, macOS 14.0, *)
 struct BudgetProgressView: View {
     @Environment(\.modelContext) private var context
     @Query(sort: [SortDescriptor(\.category)]) private var budgets: [Budget]

--- a/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
+++ b/Sources/ExpenseTracker/UI/RecurringExpenseListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import SwiftData
 import ExpenseStore
 
+@available(iOS 17.0, macOS 14.0, *)
 struct RecurringExpenseListView: View {
     @Environment(\.modelContext) private var context
     private let persistence: PersistenceController


### PR DESCRIPTION
## Summary
- bump Swift Package platforms to iOS 17 & macOS 14
- set matching deployment targets in the Xcode project
- annotate SwiftData-dependent types for iOS 17/macOS 14 availability

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68433d2364188320a55ac2a584b44124