### PR TITLE
Fix MainActor isolation around SwiftData usage

### DIFF
--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -21,6 +21,7 @@ public class CloudSyncManager {
     private let database: CKDatabaseProtocol
     private let context: ModelContext
 
+    @MainActor
     public init(container: CKContainer = .default(),
                 context: ModelContext = PersistenceController.shared.container.mainContext) {
         self.database = container.privateCloudDatabase

--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -66,6 +66,7 @@ public final class Budget {
 }
 
 @available(iOS 17.0, macOS 14.0, *)
+@MainActor
 public struct PersistenceController {
     public static let shared = PersistenceController()
     public let container: ModelContainer

--- a/Sources/ExpenseStore/RecurringExpenseScheduler.swift
+++ b/Sources/ExpenseStore/RecurringExpenseScheduler.swift
@@ -7,6 +7,7 @@ public class RecurringExpenseScheduler {
     private let context: ModelContext
     private let calendar = Calendar.current
 
+    @MainActor
     public init(context: ModelContext = PersistenceController.shared.container.mainContext) {
         self.context = context
     }

--- a/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
+++ b/Tests/ExpenseTrackerTests/ExpensesChartViewTests.swift
@@ -6,6 +6,7 @@ import ExpenseStore
 @testable import DataVisualizer
 
 final class ExpensesChartViewTests: XCTestCase {
+    @MainActor
     func testViewInitialization() {
         let controller = PersistenceController(inMemory: true)
         let ctx = controller.container.mainContext
@@ -13,6 +14,7 @@ final class ExpensesChartViewTests: XCTestCase {
         XCTAssertNotNil(view)
     }
 
+    @MainActor
     func testMonthlyTotalsSummarization() throws {
         let controller = PersistenceController(inMemory: true)
         let ctx = controller.container.mainContext

--- a/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
+++ b/Tests/ExpenseTrackerTests/PersistenceControllerTests.swift
@@ -4,6 +4,7 @@ import SwiftData
 import ExpenseStore
 
 final class PersistenceControllerTests: XCTestCase {
+    @MainActor
     func testCRUDOperations() throws {
         let container = try ModelContainer(for: ExpenseModel.self,
                                            RecurringExpenseModel.self,
@@ -35,6 +36,7 @@ final class PersistenceControllerTests: XCTestCase {
         XCTAssertEqual(results.count, 0)
     }
 
+    @MainActor
     func testRecurringAndBudgetHelpers() throws {
         let container = try ModelContainer(for: ExpenseModel.self,
                                            RecurringExpenseModel.self,
@@ -66,6 +68,7 @@ final class PersistenceControllerTests: XCTestCase {
         XCTAssertEqual(bFetch.count, 0)
     }
 
+    @MainActor
     func testAddRecurringExpenseCreatesObject() throws {
         let container = try ModelContainer(for: ExpenseModel.self,
                                            RecurringExpenseModel.self,
@@ -88,6 +91,7 @@ final class PersistenceControllerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testAddBudgetCreatesObject() throws {
         let container = try ModelContainer(for: ExpenseModel.self,
                                            RecurringExpenseModel.self,
@@ -107,6 +111,7 @@ final class PersistenceControllerTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testAddExpenseCreatesObject() throws {
         let container = try ModelContainer(for: ExpenseModel.self,
                                            RecurringExpenseModel.self,


### PR DESCRIPTION
## Summary
- mark RecurringExpenseScheduler initializer with `@MainActor`
- mark CloudSyncManager initializer with `@MainActor`
- make `PersistenceController` main-actor isolated
- update tests to run on the main actor

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_68435023cc7483209f26d931f15cd2b1