### PR TITLE
Resolve concurrency issues in SwiftData

### DIFF
--- a/Sources/ExpenseStore/RecurringExpenseScheduler.swift
+++ b/Sources/ExpenseStore/RecurringExpenseScheduler.swift
@@ -3,11 +3,11 @@ import Foundation
 import SwiftData
 
 @available(iOS 17.0, macOS 14.0, *)
+@MainActor
 public class RecurringExpenseScheduler {
     private let context: ModelContext
     private let calendar = Calendar.current
 
-    @MainActor
     public init(context: ModelContext = PersistenceController.shared.container.mainContext) {
         self.context = context
     }


### PR DESCRIPTION
## Summary
- mark RecurringExpenseScheduler and CloudSyncManager as `@MainActor`
- update initializers to safely access main context
- adjust CloudSyncManager sync logic to use an actor for capturing errors

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_684494feb824832095da70ffd311d6d3