### PR TITLE
Refactor CloudSyncManager initializer

### DIFF
--- a/Sources/ExpenseStore/CloudSyncManager.swift
+++ b/Sources/ExpenseStore/CloudSyncManager.swift
@@ -36,16 +36,14 @@ public class CloudSyncManager {
     private let database: CKDatabaseProtocol
     private let context: ModelContext
 
-    public init(container: CKContainer = .default(),
-                context: ModelContext = PersistenceController.shared.container.mainContext) {
+    public init(container: CKContainer = .default()) {
         self.database = container.privateCloudDatabase
-        self.context = context
+        self.context = PersistenceController.shared.container.mainContext
     }
 
-    public init(database: CKDatabaseProtocol,
-                context: ModelContext) {
+    public init(database: CKDatabaseProtocol) {
         self.database = database
-        self.context = context
+        self.context = PersistenceController.shared.container.mainContext
     }
 
     private func record(from expense: Expense) -> CKRecord {

--- a/Sources/ExpenseStore/ExpenseStore.swift
+++ b/Sources/ExpenseStore/ExpenseStore.swift
@@ -80,9 +80,9 @@ public struct PersistenceController {
         container = try! ModelContainer(for: schema, configurations: config)
 #if canImport(CloudKit)
         if let id = Bundle.main.object(forInfoDictionaryKey: "CloudKitContainerIdentifier") as? String {
-            cloudSync = CloudSyncManager(container: CKContainer(identifier: id), context: container.mainContext)
+            cloudSync = CloudSyncManager(container: CKContainer(identifier: id))
         } else {
-            cloudSync = CloudSyncManager(context: container.mainContext)
+            cloudSync = CloudSyncManager()
         }
         cloudSync.fetchUpdates { _ in }
 #endif

--- a/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
+++ b/Tests/ExpenseTrackerTests/CloudSyncManagerTests.swift
@@ -25,8 +25,8 @@ final class CloudSyncManagerTests: XCTestCase {
 
     func testSyncSavesRecords() throws {
         let mockDB = MockDatabase()
-        let context = PersistenceController(inMemory: true).container.viewContext
-        let manager = CloudSyncManager(database: mockDB, context: context)
+        let context = PersistenceController.shared.container.mainContext
+        let manager = CloudSyncManager(database: mockDB)
 
         let expense = Expense(context: context)
         expense.id = UUID()
@@ -46,8 +46,8 @@ final class CloudSyncManagerTests: XCTestCase {
 
     func testFetchUpdatesMergesRecords() throws {
         let mockDB = MockDatabase()
-        let context = PersistenceController(inMemory: true).container.viewContext
-        let manager = CloudSyncManager(database: mockDB, context: context)
+        let context = PersistenceController.shared.container.mainContext
+        let manager = CloudSyncManager(database: mockDB)
 
         let recordID = CKRecord.ID(recordName: UUID().uuidString)
         let record = CKRecord(recordType: "Expense", recordID: recordID)


### PR DESCRIPTION
## Summary
- update CloudSyncManager to always use the shared ModelContext
- update PersistenceController to match the new CloudSyncManager API
- adjust tests for new CloudSyncManager initializer

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6844b64de2e483208a57f5d41c144f30